### PR TITLE
Fixed volume name on troubleshooting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Upgrades for the customer portal are done automatically and require no interacti
 
 ## Troubleshooting
 
-If you get the error `[/var/www/html/storage]:rw': invalid mount config for type "volume": invalid mount path: '[/var/www/html/storage]' mount path must be absolute` during setup, try removing the created storage volume by executing `sudo docker volume rm customerportal_storage` and rerunning the installation script.
+If you get the error `[/var/www/html/storage]:rw': invalid mount config for type "volume": invalid mount path: '[/var/www/html/storage]' mount path must be absolute` during setup, try removing the created storage volume by executing `sudo docker volume rm customer_portal_storage` and rerunning the installation script.
 
 ## Customizing the portal
 


### PR DESCRIPTION
Within README the volume name was `customerportal_storage` the correct name is `customer_portal_storage`