### PR TITLE
Fixed install script showing url.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ APP_KEY="base64:$(head -c32 /dev/urandom | base64)";
 read -ep "Enter your portal domain name (such as portal.example.com): " -i "${NGINX_HOST:-}" NGINX_HOST
 read -ep "Enter Your API Username: " -i "${API_USERNAME:-}" API_USERNAME
 read -ep "Enter Your API Password: " -i "${API_PASSWORD:-}" API_PASSWORD
-read -ep "Enter Your Instance URL (e.g. https://portal.example.com): " -i "${SONAR_URL:-}" SONAR_URL
+read -ep "Enter Your Instance URL (e.g. https://example.sonar.software): " -i "${SONAR_URL:-}" SONAR_URL
 read -ep "Enter your email address: "  -i "${EMAIL_ADDRESS:-}" EMAIL_ADDRESS
 
 cat <<- EOF > ".env"


### PR DESCRIPTION
Reference Issue #21 

Install script was showing `Enter Your Instance URL (e.g. https://portal.example.com):` when it needs to show `Enter Your Instance URL (e.g. https://example.sonar.software):`

This was causing confusion when installing the customer portal.