### PR TITLE
Disable button on submit

### DIFF
--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -316,7 +316,6 @@ class BillingController extends Controller
         }
 
         if ($result->success !== true) {
-            Log::error(json_encode($result));
             throw new Exception(utrans("billing.paymentFailedTryAnother"));
         }
 
@@ -342,12 +341,10 @@ class BillingController extends Controller
         try {
             $result = $this->accountBillingController->makeCreditCardPayment(get_user()->account_id, $creditCard, $request->input('amount'), (boolean)$request->input('makeAuto'));
         } catch (Exception $e) {
-            Log::error("Failed pay with new cc. " . $e);
             throw new InvalidArgumentException(utrans("billing.errorSubmittingPayment"));
         }
 
         if ($result->success !== true) {
-            Log::error("Failed pay with new cc. Success failure. " . $result);
             throw new InvalidArgumentException(utrans("errors.paymentFailed"));
         }
 

--- a/public/assets/js/pages/billing/payment/page.js
+++ b/public/assets/js/pages/billing/payment/page.js
@@ -3,6 +3,7 @@ $(document).ready(function(){
     var expirationField = $("#expirationDate");
     var makeAuto = $("#makeAuto");
     var ccIcon = $("#ccIcon");
+    var submitted = false;
 
     ccNumberField.payment('formatCardNumber');
     expirationField.payment('formatCardExpiry');
@@ -54,6 +55,17 @@ $(document).ready(function(){
     $("#payment_method").change(function(){
         updatePaymentForm();
     });
+
+    $("#paymentForm").submit(function () {
+        submitted = true;
+        $("span:contains(error)").after(
+            submitted = false
+        );
+        if(submitted === true) {
+            $("#submit").prop('disabled', true);
+        }
+    });
+
 });
 
 function updateSubdivisions()

--- a/resources/views/pages/billing/make_payment.blade.php
+++ b/resources/views/pages/billing/make_payment.blade.php
@@ -160,7 +160,7 @@
                </small>
             </div>
             <div class="col-12 col-md-12 mt-5">
-               <button type="submit" class="btn btn-primary">{{utrans("billing.submitPayment")}}</button>
+               <button id="submit" type="submit" class="btn btn-primary">{{utrans("billing.submitPayment")}}</button>
             </div>
             {!! Form::close() !!}
          </div>


### PR DESCRIPTION
This PR is to fix an issue with customers hitting the pay button multiple times when the first call hasn't completed yet.

- Disable the button on submit if page validation passes. If any element contains "error" (example city-error) then keep the button enabled.
- Removed detailed logging