### PR TITLE
Fixed misspelling in config page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN add-apt-repository ppa:ondrej/php \
       gettext \
       nginx \
       php7.3-fpm \
-      php-bcmath \
-      php-curl \
-      php-gmp \
-      php-mbstring \
-      php-sqlite3 \
-      php-zip \
+      php7.3-bcmath \
+      php7.3-curl \
+      php7.3-gmp \
+      php7.3-mbstring \
+      php7.3-sqlite3 \
+      php7.3-zip \
       unzip
 
 WORKDIR /var/www/html

--- a/resources/views/pages/config/show.blade.php
+++ b/resources/views/pages/config/show.blade.php
@@ -198,7 +198,7 @@
                <div class="col-12 ">
                   <div class="form-group">
                      <label>
-                     Decimal Seperator
+                     Decimal Separator
                      </label>
                      {!! Form::text("decimal_separator",$systemSetting->decimal_separator,['id' => 'decimal_separator', 'class' => 'form-control', 'placeholder' => ".", 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The symbol to be used as a decimal, eg $34<strong>.</strong>95']) !!}
                   </div>
@@ -208,7 +208,7 @@
                <div class="col-12 ">
                   <div class="form-group">
                      <label>
-                     Thousands Seperator
+                     Thousands Separator
                      </label>
                      <div class="input-group mb-3">
                         {!! Form::text("thousands_separator",$systemSetting->thousands_separator,['id' => 'thousands_separator', 'class' => 'form-control', 'placeholder' => ",", 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The symbol to be used as a comma, eg $3<strong>,</strong>953']) !!}


### PR DESCRIPTION
Corrected spelling issue with `Separator` in config page.