### PR TITLE
Revert PHP to 7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ RUN add-apt-repository ppa:ondrej/php \
  && install_clean \
       gettext \
       nginx \
-      php7.4-fpm \
-      php7.4-bcmath \
-      php7.4-curl \
-      php7.4-gmp \
-      php7.4-mbstring \
-      php7.4-sqlite3 \
-      php7.4-zip \
+      php7.3-fpm \
+      php7.3-bcmath \
+      php7.3-curl \
+      php7.3-gmp \
+      php7.3-mbstring \
+      php7.3-sqlite3 \
+      php7.3-zip \
       unzip
 
 WORKDIR /var/www/html
@@ -31,7 +31,7 @@ RUN COMPOSER_CACHE_DIR=/dev/null setuser www-data /tmp/composer install --no-dev
 
 COPY deploy/conf/nginx/sonar-customerportal.template /etc/nginx/conf.d/customerportal.template
 
-COPY deploy/conf/php-fpm/ /etc/php/7.4/fpm/
+COPY deploy/conf/php-fpm/ /etc/php/7.3/fpm/
 
 COPY deploy/conf/cron.d/* /etc/cron.d/
 

--- a/deploy/90_init_fpm.sh
+++ b/deploy/90_init_fpm.sh
@@ -2,5 +2,5 @@
 set -euf -o pipefail
 
 mkdir -p /run/php
-touch /run/php/php7.4-fpm.sock
-chown www-data:www-data /run/php/php7.4-fpm.sock
+touch /run/php/php7.3-fpm.sock
+chown www-data:www-data /run/php/php7.3-fpm.sock

--- a/deploy/conf/nginx/sonar-customerportal.template
+++ b/deploy/conf/nginx/sonar-customerportal.template
@@ -35,7 +35,7 @@ server {
     }
 
     location ~ ^/.+\.php(/|$) {
-        fastcgi_pass unix:/run/php/php7.4-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }

--- a/deploy/services/php-fpm.sh
+++ b/deploy/services/php-fpm.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/sbin/php-fpm7.4 -F
+exec /usr/sbin/php-fpm7.3 -F


### PR DESCRIPTION
The version of swiftmailer used in Laravel 5.5 does not work with PHP 7.4 due to its dependency on egulias/EmailValidator: https://github.com/egulias/EmailValidator/issues/212

Bump PHP back for now.