### PR TITLE
Unclosed Tag

### DIFF
--- a/resources/views/pages/billing/make_payment.blade.php
+++ b/resources/views/pages/billing/make_payment.blade.php
@@ -162,8 +162,8 @@
             <div class="col-12 col-md-12 mt-5">
                <button id="submit" type="submit" class="btn btn-primary">{{utrans("billing.submitPayment")}}</button>
             </div>
-            {!! Form::close() !!}
          </div>
+         {!! Form::close() !!}
       </div>
       <!-- / .row -->
    </div>


### PR DESCRIPTION
Customer portal payments are not applying, the only issue I could see was that the closing form/div tag where out of order, and the browser showed that as an error. Re-ordered the tags and it seems to work now (for submit payment)