### PR TITLE
Updated cron job permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY deploy/conf/nginx/sonar-customerportal.template /etc/nginx/conf.d/customerp
 COPY deploy/conf/php-fpm/ /etc/php/7.3/fpm/
 
 COPY deploy/conf/cron.d/* /etc/cron.d/
+RUN chmod -R 644 /etc/cron.d
 
 RUN mkdir -p /etc/my_init.d
 COPY deploy/*.sh /etc/my_init.d/


### PR DESCRIPTION
Error in log -> 
sonar-customerportal | Feb 10 17:10:02 f1cb88058c97 cron[76]: (*system*laravel-cron) INSECURE MODE (group/other writable) (/etc/cron.d/laravel-cron)
sonar-customerportal | Feb 10 17:10:02 f1cb88058c97 cron[76]: (*system*nginx-reload-certs) INSECURE MODE (group/other writable) (/etc/cron.d/nginx-reload-certs)

Fixed by applying permissions 600/644 to /etc/cron.d (cron jobs aren't running)