### PR TITLE
Added hashes for inline JS scripts for CSP

### DIFF
--- a/deploy/conf/nginx/sonar-customerportal.template
+++ b/deploy/conf/nginx/sonar-customerportal.template
@@ -25,8 +25,8 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    add_header Content-Security-Policy "frame-src 'self' https://js.stripe.com; frame-ancestors 'none'; form-action 'self' https://www.paypal.com; upgrade-insecure-requests; script-src 'self' https://js.stripe.com; connect-src 'self' https://api.stripe.com;";
-
+    add_header Content-Security-Policy "frame-src 'self' https://js.stripe.com; frame-ancestors 'none'; form-action 'self' https://www.paypal.com; upgrade-insecure-requests; script-src 'self' 'sha256-8MEQ/Qvo0Y09Vo5TDuyuOW39tu8QgAkymm2kKnkZ4iU=' 'sha256-hCdV2+S+9aRKKJlfK5CGe8NOfdvwBm9EvUlaeGXu0rE=' 'sha256-gzorWt76ec20Vfh2hf2HnxowkJXaHEJ2HinEBjvK6X4=' https://js.stripe.com; connect-src 'self' https://api.stripe.com;";
+    
     root /var/www/html/public;
     index index.php;
 


### PR DESCRIPTION
script-scr self disallows inlining, added the hashes for the three scripts in payment that are inline scripts so they CSP doesn't shut them down.