### PR TITLE
Update index.blade.php

### DIFF
--- a/resources/views/pages/root/index.blade.php
+++ b/resources/views/pages/root/index.blade.php
@@ -11,7 +11,11 @@
          @endif
          <h1 class="fake-half">{{trans('actions.loginMessage', ['ispName' => config("customer_portal.company_name")],$language)}}</h1>
          {!! Form::open(['action' => 'AuthenticationController@authenticate']) !!}
-	     <input type="hidden" name="language" value="{{$language}}">
+             @if (empty($language))
+                 <input type="hidden" name="language" value="en">
+             @else
+                 <input type="hidden" name="language" value="{{$language}}">
+             @endif
          <div class="label label-text">
             <label for="input-email">{{trans("root.username",[],$language)}}</label>
             {!! Form::text("username",null,['placeholder' => trans("root.username",[],$language), 'id' => 'username']) !!}


### PR DESCRIPTION
Laravel is buggy in the locale department, even though we specify a default locale of eng in app/

When you go into the container and run php tinker, both config('app.local'); and App::getLocale() are null -- if you go into the settings page, then set a language and save it, then it gets saved into the system default locale. This locale string is pulled automatically by the blade template and is null, so the value doesn't get populated which causes the login error about the language. Once the language is set, users can log in.