### PR TITLE
Lock containerd.io at version 1.4.4-1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ if ! [ -x "$(command -v docker)" ]; then
        $(lsb_release -cs) \
        stable"
     apt-get update
-    apt-get install -y docker-ce docker-ce-cli containerd.io
+    apt-get install -y docker-ce docker-ce-cli containerd.io=1.4.4-1
 fi
 
 if ! [ -x "$(command -v docker-compose)" ]; then


### PR DESCRIPTION
newest version of containerd causes install to fail; locking at 1.4.4-1