### PR TITLE
Change volume definition in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,5 @@ COPY deploy/services/php-fpm.sh /etc/service/php-fpm/run
 RUN mkdir /etc/service/nginx
 COPY deploy/services/nginx.sh /etc/service/nginx/run
 
-VOLUME ['/var/www/html/storage']
+VOLUME /var/www/html/storage
 EXPOSE 80 443


### PR DESCRIPTION
Update storage volume in Dockerfile otherwise okteto will not deploy the containers.

The image below should be tagged and pushed as `sonarsoftware/customerportal:latest`, as the `okteto.Dockerfile` specifies the `latest` tag (I cannot push to the repository).

https://hub.docker.com/layers/sonarsoftware/customerportal/83efbaf1240a552ffa030ba99ce8a3fddd833785/images/sha256-cb5911ce150ad12a112c80e771d47a2864bb37a6a8045e0d3f276640b089468c?context=explore

Discussion: https://sonarsoftware.slack.com/archives/G01G864R26A/p1624400116043100
