### PR TITLE
Remove Stripe API token message about v2/v1

### DIFF
--- a/resources/views/pages/config/show.blade.php
+++ b/resources/views/pages/config/show.blade.php
@@ -421,13 +421,6 @@
                   </div>
                </div>
             </div>
-            <div class="row mt-1">
-               <div class="col-12">
-                   <p class="text-muted">
-                     <i>* This is required to use Stripe with Sonar version 2. Version 1 users may still use Stripe without enabling this.</i>
-                   </p>
-               </div>
-            </div>
       </div>
    </div>
 


### PR DESCRIPTION
Related to the V1 stripe Stripe PR. 

Removes this text in `customer-portal.com/settings`

![stripe_settings](https://user-images.githubusercontent.com/9061227/123340320-3f65f300-d509-11eb-8e36-a210692c7517.png)
