### PR TITLE
AB#3212 Don't break the page if there is no historical data usage.

### DIFF
--- a/app/Http/Controllers/DataUsageController.php
+++ b/app/Http/Controllers/DataUsageController.php
@@ -26,7 +26,7 @@ class DataUsageController extends Controller
     {
         $historicalUsage = $this->getHistoricalUsage();
         $policyDetails = $this->getPolicyDetails();
-        $currentUsage = $historicalUsage[0];
+        $currentUsage = $historicalUsage ? $historicalUsage[0] : [];
         $historicalUsage = json_encode($historicalUsage);
         $calculatedCap = $policyDetails->policy_cap_in_gigabytes + round($policyDetails->rollover_available_in_bytes/1000**3, 2) + round($policyDetails->purchased_top_off_total_in_bytes/1000**3, 2);
         if ($calculatedCap > 0) {

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -1,8 +1,12 @@
 @extends('layouts.full')
 @section('content')
+@if (isset($values["currentUsage"]["billable"]))
 <style nonce="{{ csp_nonce() }}">
-   #usage-progressbar { width: {{$values["currentUsage"]["billable"]}}% }
+   #usage-progressbar {
+     width:  {{$values["currentUsage"]["billable"]}}%
+   }
 </style>
+@endif
 <!-- HEADER -->
 <div class="header index-bg pb-5">
    <div class="container-fluid">
@@ -236,12 +240,12 @@
                      @foreach($transactions as $transaction)
                      <tr>
                         <td>
-                           @if(in_array($transaction['type'],['debit','discount'])) 
+                           @if(in_array($transaction['type'],['debit','discount']))
                            <span class="badge-lg pl-2">{{$transaction['description']}}</span>
                            @else
                            <span class="@if($transaction['type'] != "debit") badge-lg rounded p-2 badge-soft-success @else badge-lg @endif">
                            {{utrans("transaction_types." . $transaction['type'])}}
-                           </span>     
+                           </span>
                            @endif
                         </td>
                         <td>{{Formatter::date($transaction['date'],false)}}</td>


### PR DESCRIPTION
https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/3212

In sonar (v2), whenever an account transitions from some status to 'Active', a HistoricalDataUsage is created for it. This didn't always happen, though - so there are accounts with no HistoricalDataUsage, which will break the Data Usage and Billing pages of the Customer Portal. 

Here, we add some conditions to provide default values if the history doesn't exist. 

There is another PR in sonar to create DataUsageHistories for all active accounts, which is this: https://github.com/SonarSoftwareInc/sonar/pull/3305. Which should prevent these conditions from ever being needed. 

![Screenshot from 2021-07-07 14-59-12](https://user-images.githubusercontent.com/9061227/124828030-fadc4d80-df33-11eb-9005-5f2e2bd814d1.png)

![Screenshot from 2021-07-07 14-59-24](https://user-images.githubusercontent.com/9061227/124828038-fc0d7a80-df33-11eb-8266-9a2b42e032ea.png)

Instead of 

![Screenshot from 2021-07-07 15-00-33](https://user-images.githubusercontent.com/9061227/124828151-1e06fd00-df34-11eb-9106-a56683cf7640.png)
![Screenshot from 2021-07-07 15-00-19](https://user-images.githubusercontent.com/9061227/124828155-1f382a00-df34-11eb-9d6b-567f7308497b.png)

