### PR TITLE
AB#4334 Fix CSP violations

### DIFF
--- a/resources/views/layouts/partials/js.blade.php
+++ b/resources/views/layouts/partials/js.blade.php
@@ -34,4 +34,16 @@ close=document.getElementById("close");close.addEventListener('click',function()
        return _portal.currencySymbol + s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
    };
 </script>
+<script nonce="{{ csp_nonce() }}">
+    $(document).ready(function() {
+        $('.btn-disable-with-msg-on-click').each(function(idx, button) {
+            $(button).on('click', function() {
+                $(this.form).submit();
+                var $button = $(this);
+                $button.html('<i class="fe fe-loader mt-2 mr-2"> ' + $button.data('message') + '</i>');
+                $button.prop('disabled', true);
+            });
+        });
+    });
+</script>
 @yield('additionalJS')

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -310,13 +310,13 @@
                         <TD class="text-right">
                            @if($paymentMethod->auto == 1)
                            {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
-                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.disabling")}}">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" data-message="{{utrans("billing.disabling")}}">
                            <i class="fe fe-minus-circle mr-2"></i> {{utrans("billing.disableAuto")}}
                            </button>
                            {!! Form::close() !!}
                            @else
                            {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
-                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.enabling")}}">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" data-message="{{utrans("billing.enabling")}}">
                            <i class="fe fe-check-circle mr-2"></i> {{utrans("billing.enableAuto")}}
                            </button>
                            {!! Form::close() !!}
@@ -324,7 +324,7 @@
                         </TD>
                         <TD class="text-right">
                            {!! Form::open(['action' => ["BillingController@deletePaymentMethod",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'delete']) !!}
-                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.deleting")}}'">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" data-message="{{utrans("billing.deleting")}}'">
                            <i class="fe fe-x-circle mr-2"></i>
                            {{utrans("actions.delete")}}
                            </button>
@@ -333,19 +333,6 @@
                      </TR>
                      @endif
                      @endforeach
-                     <script nonce="{{ csp_nonce() }}">
-
-                        function disableWithMessage(button) {
-                           button.innerHTML = '<i class="fe fe-loader mt-2 mr-2">' + button.getAttribute('data-message') + '</i>';
-                           button.disabled = true;
-                        }
-
-                        var buttons = document.getElementById('credit_cards_table').getElementsByClassName('btn-disable-with-msg-on-click');
-                        for (var idx = 0; idx < buttons.length; idx++) {
-                           buttons[idx].addEventListener('click', function(){ disableWithMessage(this); });
-                        }
-
-                     </script>
                      @endif
                   </tbody>
                </table>

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -284,7 +284,7 @@
                </p>
             </div>
             <div class="table-responsive">
-               <table class="table table-sm card-table" id="credit_cards_table">
+               <table class="table table-sm card-table">
                   <thead>
                      <tr>
                         <th>{{utrans("billing.last4")}}</th>

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -336,7 +336,7 @@
                      <script nonce="{{ csp_nonce() }}">
 
                         function disableWithMessage(button) {
-                           button.innerHTML = '<i class="fe fe-loader mt-2 mr-2"></i> ' + button.getAttribute('data-message');
+                           button.innerHTML = '<i class="fe fe-loader mt-2 mr-2">' + button.getAttribute('data-message') + '</i>';
                            button.disabled = true;
                         }
 

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -284,7 +284,7 @@
                </p>
             </div>
             <div class="table-responsive">
-               <table class="table table-sm card-table">
+               <table class="table table-sm card-table" id="credit_cards_table">
                   <thead>
                      <tr>
                         <th>{{utrans("billing.last4")}}</th>
@@ -310,13 +310,13 @@
                         <TD class="text-right">
                            @if($paymentMethod->auto == 1)
                            {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
-                           <button class="btn btn-sm" onClick="submit(); this.disabled=true;this.innerHTML='<i class=&quot;fe fe-loader mt-2 mr-2 &quot;></i> {{utrans("billing.disabling")}}'">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.disabling")}}">
                            <i class="fe fe-minus-circle mr-2"></i> {{utrans("billing.disableAuto")}}
                            </button>
                            {!! Form::close() !!}
                            @else
                            {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
-                           <button class="btn btn-sm " onClick="submit(); this.disabled=true;this.innerHTML='<i class=&quot;fe fe-loader mt-2 mr-2&quot;></i> {{utrans("billing.enabling")}}'">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.enabling")}}">
                            <i class="fe fe-check-circle mr-2"></i> {{utrans("billing.enableAuto")}}
                            </button>
                            {!! Form::close() !!}
@@ -324,7 +324,7 @@
                         </TD>
                         <TD class="text-right">
                            {!! Form::open(['action' => ["BillingController@deletePaymentMethod",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'delete']) !!}
-                           <button class="btn btn-sm" onClick="submit(); this.disabled=true;this.innerHTML='<i class=&quot;fe fe-loader mt-2 mr-2 &quot;></i> {{utrans("billing.deleting")}}'">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" type="submit" data-message="{{utrans("billing.deleting")}}'">
                            <i class="fe fe-x-circle mr-2"></i>
                            {{utrans("actions.delete")}}
                            </button>
@@ -333,6 +333,22 @@
                      </TR>
                      @endif
                      @endforeach
+                     <script nonce="{{ csp_nonce() }}">
+
+                        function disableWithMessage(button) {
+                           button.innerHTML = '<i class="fe fe-loader mt-2 mr-2"></i> ' + button.getAttribute('data-message');
+                           button.disabled = true;
+                        }
+
+                        var buttons = document.getElementById('credit_cards_table').getElementsByClassName('btn-disable-with-msg-on-click');
+                        for (var idx in buttons) {
+                           if (! buttons.hasOwnProperty(idx)) {
+                              continue;
+                           }
+                           buttons[idx].addEventListener('click', function(){ disableWithMessage(this); });
+                        }
+
+                     </script>
                      @endif
                   </tbody>
                </table>

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -309,13 +309,13 @@
                         <TD>{{$paymentMethod->expiration_month}}/{{$paymentMethod->expiration_year}}</TD>
                         <TD class="text-right">
                            @if($paymentMethod->auto == 1)
-                           {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'patch']) !!}
+                           {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
                            <button class="btn btn-sm" onClick="submit(); this.disabled=true;this.innerHTML='<i class=&quot;fe fe-loader mt-2 mr-2 &quot;></i> {{utrans("billing.disabling")}}'">
                            <i class="fe fe-minus-circle mr-2"></i> {{utrans("billing.disableAuto")}}
                            </button>
                            {!! Form::close() !!}
                            @else
-                           {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'patch']) !!}
+                           {!! Form::open(['action' => ["BillingController@toggleAutoPay",$paymentMethod->id],'id' => 'enablePaymentMethodForm', 'method' => 'patch']) !!}
                            <button class="btn btn-sm " onClick="submit(); this.disabled=true;this.innerHTML='<i class=&quot;fe fe-loader mt-2 mr-2&quot;></i> {{utrans("billing.enabling")}}'">
                            <i class="fe fe-check-circle mr-2"></i> {{utrans("billing.enableAuto")}}
                            </button>
@@ -343,25 +343,25 @@
             @if(config("customer_portal.enable_bank_payments") == 1 || config("customer_portal.enable_gocardless") == 1)
             <div class="col-12 col-md-12 col-xl-12">
                <div class="card">
-                     <div class="card-header">
-                        <h4 class="card-header-title text-muted"><i class="fe fe-dollar-sign mr-3"></i> {{utrans("headers.bankAccounts")}}</h4>
-                        <p class="text-right mt-3">
-                           <a class="btn btn-secondary btn-sm" href="{{action("BillingController@createPaymentMethod",['type' => 'bank'])}}" role="button">
-                              <i class="fe fe-plus"></i> {{utrans("billing.addNewBankAccount")}}</a>
-                        </p>
-                     </div>
+                  <div class="card-header">
+                     <h4 class="card-header-title text-muted"><i class="fe fe-dollar-sign mr-3"></i> {{utrans("headers.bankAccounts")}}</h4>
+                     <p class="text-right mt-3">
+                        <a class="btn btn-secondary btn-sm" href="{{action("BillingController@createPaymentMethod",['type' => 'bank'])}}" role="button">
+                           <i class="fe fe-plus"></i> {{utrans("billing.addNewBankAccount")}}</a>
+                     </p>
+                  </div>
                   <div class="table-responsive">
                      <table class="table table-sm card-table">
                         <thead>
                            <tr>
                               <th>{{utrans("billing.accountNumber")}}</th>
-                              <th></th>
+                              <th colspan="2"></th>
                            </tr>
                         </thead>
                         <tbody>
                            @if(count($paymentMethods) === 0)
                               <TR>
-                                 <TD colspan="2">{{utrans("billing.noBankAccounts")}}</TD>
+                                 <TD colspan="3">{{utrans("billing.noBankAccounts")}}</TD>
                               </TR>
                            @else
                            @foreach($paymentMethods as $paymentMethod)
@@ -385,7 +385,7 @@
                                  {{utrans("billing.enableAuto")}}
                                  </button>
                                  {!! Form::close() !!}
-                                    @endif
+                                 @endif
                               </TD>
                               <TD class="text-right">
                                  {!! Form::open(['action' => ["BillingController@deletePaymentMethod",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'delete']) !!}
@@ -401,59 +401,58 @@
                            @endif
                         </tbody>
                      </table>
-                     </div>
-                     </div>
                   </div>
-                  @endif
                </div>
             </div>
-            <div class="col-12 col-md-12 col-xl-6">
-               <div class="card">
-                  <div class="card-header">
-                     <h4 class="card-header-title text-muted">
-                        <i class="fe fe-inbox mr-3"></i>{{utrans("headers.invoices")}}
-                     </h4>
-                  </div>
-                  <div class="table-responsive">
-                     <table class="table table-sm card-table">
-                        <thead>
-                           <tr>
-                              <th>{{utrans("general.date")}}</th>
-                              <th>{{utrans("billing.invoiceNumber")}}</th>
-                              <th>{{utrans("billing.remainingDue")}}</th>
-                              <th>{{utrans("billing.dueDate")}}</th>
-                              <th>{{utrans("billing.viewInvoice")}}</th>
-                           </tr>
-                        </thead>
-                        <tbody>
-                           @if(count($invoices) == 0)
-                           <TR>
-                              <TD colspan="4">{{utrans("billing.noInvoicesFound")}}</TD>
-                           </TR>
-                           @else
-                           @foreach($invoices as $invoice)
-                           <TR>
-                              <TD>{{Formatter::date($invoice->date,false)}}</TD>
-                              <TD>{{$invoice->id}}</TD>
-                              <TD>{{Formatter::currency(bcadd($invoice->remaining_due, $invoice->child_remaining_due,2))}}</TD>
-                              <TD>{{Formatter::date($invoice->due_date,false)}}</TD>
-                              <TD>
-                                 <a class="btn btn-sm" href="{{action("BillingController@getInvoicePdf",['invoices' => $invoice->id])}}" role="button">
-                                 <i class="fe fe-file-text mr-1"></i>
-                                 {{utrans("billing.downloadInvoice")}}
-                                 </a>
-                              </TD>
-                           </TR>
-                           @endforeach
-                           @endif
-                        </tbody>
-                     </table>
-                      {{ $invoices->links() }}
-                  </div>
-               </div>
+            @endif
+         </div>
+      </div>
+      <div class="col-12 col-md-12 col-xl-6">
+         <div class="card">
+            <div class="card-header">
+               <h4 class="card-header-title text-muted">
+                  <i class="fe fe-inbox mr-3"></i>{{utrans("headers.invoices")}}
+               </h4>
+            </div>
+            <div class="table-responsive">
+               <table class="table table-sm card-table">
+                  <thead>
+                     <tr>
+                        <th>{{utrans("general.date")}}</th>
+                        <th>{{utrans("billing.invoiceNumber")}}</th>
+                        <th>{{utrans("billing.remainingDue")}}</th>
+                        <th>{{utrans("billing.dueDate")}}</th>
+                        <th>{{utrans("billing.viewInvoice")}}</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     @if(count($invoices) == 0)
+                     <TR>
+                        <TD colspan="5">{{utrans("billing.noInvoicesFound")}}</TD>
+                     </TR>
+                     @else
+                     @foreach($invoices as $invoice)
+                     <TR>
+                        <TD>{{Formatter::date($invoice->date,false)}}</TD>
+                        <TD>{{$invoice->id}}</TD>
+                        <TD>{{Formatter::currency(bcadd($invoice->remaining_due, $invoice->child_remaining_due,2))}}</TD>
+                        <TD>{{Formatter::date($invoice->due_date,false)}}</TD>
+                        <TD>
+                           <a class="btn btn-sm" href="{{action("BillingController@getInvoicePdf",['invoices' => $invoice->id])}}" role="button">
+                           <i class="fe fe-file-text mr-1"></i>
+                           {{utrans("billing.downloadInvoice")}}
+                           </a>
+                        </TD>
+                     </TR>
+                     @endforeach
+                     @endif
+                  </tbody>
+               </table>
+                {{ $invoices->links() }}
             </div>
          </div>
       </div>
    </div>
 </div>
+</div><!-- #main-content -->
 @endsection

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -324,7 +324,7 @@
                         </TD>
                         <TD class="text-right">
                            {!! Form::open(['action' => ["BillingController@deletePaymentMethod",$paymentMethod->id],'id' => 'deletePaymentMethodForm', 'method' => 'delete']) !!}
-                           <button class="btn btn-sm btn-disable-with-msg-on-click" data-message="{{utrans("billing.deleting")}}'">
+                           <button class="btn btn-sm btn-disable-with-msg-on-click" data-message="{{utrans("billing.deleting")}}">
                            <i class="fe fe-x-circle mr-2"></i>
                            {{utrans("actions.delete")}}
                            </button>

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -261,7 +261,8 @@
                      @endforeach
                      @endif
                      @endforeach
-                     @endif
+                  </tbody>
+                  @endif
                </table>
                 {{ $transactions->links() }}
             </div>
@@ -288,13 +289,13 @@
                      <tr>
                         <th>{{utrans("billing.last4")}}</th>
                         <th>{{utrans("billing.expiration")}}</th>
-                        <th></th>
+                        <th colspan="2"></th>
                      </tr>
                   </thead>
                   <tbody>
                      @if(count($paymentMethods) === 0)
                      <TR>
-                        <TD colspan="3">{{utrans("billing.noCreditCardsOnFile")}}</TD>
+                        <TD colspan="4">{{utrans("billing.noCreditCardsOnFile")}}</TD>
                      </TR>
                      @else
                      @foreach($paymentMethods as $paymentMethod)
@@ -329,7 +330,6 @@
                            </button>
                            {!! Form::close() !!}
                         </TD>
-                        </div>
                      </TR>
                      @endif
                      @endforeach

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -341,10 +341,7 @@
                         }
 
                         var buttons = document.getElementById('credit_cards_table').getElementsByClassName('btn-disable-with-msg-on-click');
-                        for (var idx in buttons) {
-                           if (! buttons.hasOwnProperty(idx)) {
-                              continue;
-                           }
+                        for (var idx = 0; idx < buttons.length; idx++) {
                            buttons[idx].addEventListener('click', function(){ disableWithMessage(this); });
                         }
 


### PR DESCRIPTION
This PR fixes a couple of CSP violations on the billing index page caused by some inlined JS in onclick attributes of buttons. I extracted the onclick to a function and added event listeners for the few buttons that needed it.

Before, when clicking the enable/disable autopay button on a credit card, the request is in flight but the button content has not updated:
<img width="825" alt="ab4296-before" src="https://user-images.githubusercontent.com/68166329/181063012-738d904a-2821-4e11-8bdd-e0b2fd5747b5.PNG">

After, when clicking the enable/disable autopay button on a credit card, the request is in flight and the button content has updated:
<img width="530" alt="ab4296-after" src="https://user-images.githubusercontent.com/68166329/181063334-9f93252f-35d0-4b36-8ca7-ef1a1f29b1fa.PNG">

