### PR TITLE
AB#5540 CSP is preventing loading of legitimate resources

### DIFF
--- a/okteto-stack.yml
+++ b/okteto-stack.yml
@@ -15,9 +15,9 @@ services:
       - API_PASSWORD=sonar
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - NGINX_HOST=customer-portal-${OKTETO_NAMESPACE}.sonar.church
-      - SONAR_URL=http://web-${OKTETO_NAMESPACE}.sonar.church:8080
-      - OKTETO_SONAR_HOST=web-${OKTETO_NAMESPACE}.sonar.church
+      - NGINX_HOST=customer-portal-${OKTETO_NAMESPACE}.sonar.rocks
+      - SONAR_URL=http://web-${OKTETO_NAMESPACE}.sonar.rocks:8080
+      - OKTETO_SONAR_HOST=web-${OKTETO_NAMESPACE}.sonar.rocks
     annotations:
       dev.okteto.com/auto-ingress: "private"
       dev.okteto.com/generate-host: "true"

--- a/public/assets/css/theme.css
+++ b/public/assets/css/theme.css
@@ -3262,13 +3262,13 @@ input[type='button'].btn-block {
 	background-color: var(--primary);;
 }
 .custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 8 8\'%3E%3Cpath fill=\'%23FFFFFF\' d=\'M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/cb-checked.svg');
 }
 .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
 	background-color: var(--primary);;
 }
 .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 4 4\'%3E%3Cpath stroke=\'%23FFFFFF\' d=\'M0 2h4\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/cb-indeterminate.svg');
 }
 .custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
 	background-color: rgba(44, 123, 229, .5);
@@ -3283,7 +3283,7 @@ input[type='button'].btn-block {
 	background-color: var(--primary);;
 }
 .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'-4 -4 8 8\'%3E%3Ccircle r=\'3\' fill=\'%23FFFFFF\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/radio-checked.svg');
 }
 .custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
 	background-color: rgba(44, 123, 229, .5);
@@ -3298,7 +3298,7 @@ input[type='button'].btn-block {
 	color: #12263f;
 	border: 1px solid #d2ddec;
 	border-radius: .375rem;
-	background: #fff url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 4 5\'%3E%3Cpath fill=\'%233B506C\' d=\'M2 0L0 2h4zm0 5L0 3h4z\'/%3E%3C/svg%3E') no-repeat right .75rem center;
+	background: #fff url('/assets/svg/select.svg') no-repeat right .75rem center;
 	background-size: 8px 10px;
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -3834,7 +3834,7 @@ input[type='button'].btn-block {
 	border-color: transparent;
 }
 .navbar-light .navbar-toggler-icon {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg viewBox=\'0 0 30 30\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath stroke=\'%236E84A3\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-miterlimit=\'10\' d=\'M4 7h22M4 15h22M4 23h22\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/toggler-light.svg');
 }
 .navbar-light .navbar-text {
 	color: #6e84a3;
@@ -3874,7 +3874,7 @@ input[type='button'].btn-block {
 	border-color: transparent;
 }
 .navbar-dark .navbar-toggler-icon {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg viewBox=\'0 0 30 30\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath stroke=\'rgba(255, 255, 255, 0.5)\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-miterlimit=\'10\' d=\'M4 7h22M4 15h22M4 23h22\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/toggler-dark.svg');
 }
 .navbar-dark .navbar-text {
 	color: rgba(255, 255, 255, .5);
@@ -5314,10 +5314,10 @@ button.close {
 	background-size: 100% 100%;
 }
 .carousel-control-prev-icon {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' fill=\'%23FFFFFF\' viewBox=\'0 0 8 8\'%3E%3Cpath d=\'M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/carousel-prev.svg');
 }
 .carousel-control-next-icon {
-	background-image: url('data:image/svg+xml;charset=utf8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' fill=\'%23FFFFFF\' viewBox=\'0 0 8 8\'%3E%3Cpath d=\'M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z\'/%3E%3C/svg%3E');
+	background-image: url('/assets/svg/carousel-next.svg');
 }
 .carousel-indicators {
 	position: absolute;
@@ -9603,8 +9603,8 @@ a.text-body:focus {
 	height: .6rem;
 	margin-right: .5rem;
 	background: #d2ddec;
-	-webkit-mask: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSIxMHB4IiBoZWlnaHQ9IjE2cHgiIHZpZXdCb3g9IjAgMCAxMCAxNiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5TaGFwZTwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+ICAgICAgICA8ZyBpZD0iY2hldnJvbi1yaWdodCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMi4wMDAwMDAsIDIuMDAwMDAwKSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjIuNSI+ICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJTaGFwZSIgcG9pbnRzPSIwIDEyIDYgNiAwIDAiPjwvcG9seWxpbmU+ICAgICAgICA8L2c+ICAgIDwvZz48L3N2Zz4=) no-repeat 50% 50%;
-	mask: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSIxMHB4IiBoZWlnaHQ9IjE2cHgiIHZpZXdCb3g9IjAgMCAxMCAxNiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5TaGFwZTwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+ICAgICAgICA8ZyBpZD0iY2hldnJvbi1yaWdodCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMi4wMDAwMDAsIDIuMDAwMDAwKSIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjIuNSI+ICAgICAgICAgICAgPHBvbHlsaW5lIGlkPSJTaGFwZSIgcG9pbnRzPSIwIDEyIDYgNiAwIDAiPjwvcG9seWxpbmU+ICAgICAgICA8L2c+ICAgIDwvZz48L3N2Zz4=) no-repeat 50% 50%;
+	-webkit-mask: url('/assets/svg/breadcrumb-mask.svg') no-repeat 50% 50%;
+	mask: url('/assets/svg/breadcrumb-mask.svg') no-repeat 50% 50%;
 	-webkit-mask-size: contain;
 	mask-size: contain;
 }
@@ -10998,7 +10998,7 @@ body {
 }
 .table[data-sort]::after {
 	margin-left: .25rem;
-	content: url('data:image/svg+xml;utf8,<svg width=\'6\' height=\'10\' viewBox=\'0 0 6 10\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'><path fill-rule=\'evenodd\' clip-rule=\'evenodd\' d=\'M3 0L6 4H0L3 0ZM3 10L0 6H6L3 10Z\' fill=\'%2395AAC9\'/></svg>');
+	content: url('/assets/svg/sort.svg');
 }
 h1,
 .h1 {

--- a/public/assets/svg/breadcrumb-mask.svg
+++ b/public/assets/svg/breadcrumb-mask.svg
@@ -1,0 +1,8 @@
+<svg width="10px" height="16px" viewBox="0 0 10 16" version="1.1" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="chevron-right" transform="translate(2.000000, 2.000000)" stroke="#000000" stroke-width="2.5">
+            <polyline points="0 12 6 6 0 0"/>
+        </g>
+    </g>
+</svg>

--- a/public/assets/svg/carousel-next.svg
+++ b/public/assets/svg/carousel-next.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' fill='#FFFFFF' viewBox='0 0 8 8'>
+    <path d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/>
+</svg>

--- a/public/assets/svg/carousel-prev.svg
+++ b/public/assets/svg/carousel-prev.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' fill='#FFFFFF' viewBox='0 0 8 8'>
+    <path d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/>
+</svg>

--- a/public/assets/svg/cb-checked.svg
+++ b/public/assets/svg/cb-checked.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'>
+    <path fill='#FFFFFF' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/>
+</svg>

--- a/public/assets/svg/cb-indeterminate.svg
+++ b/public/assets/svg/cb-indeterminate.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'>
+    <path stroke='#FFFFFF' d='M0 2h4'/>
+</svg>

--- a/public/assets/svg/radio-checked.svg
+++ b/public/assets/svg/radio-checked.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'>
+    <circle r='3' fill='#FFFFFF'/>
+</svg>

--- a/public/assets/svg/select.svg
+++ b/public/assets/svg/select.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'>
+    <path fill='#3B506C' d='M2 0L0 2h4zm0 5L0 3h4z'/>
+</svg>

--- a/public/assets/svg/sort.svg
+++ b/public/assets/svg/sort.svg
@@ -1,0 +1,3 @@
+<svg width='6' height='10' viewBox='0 0 6 10' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <path fill-rule='evenodd' clip-rule='evenodd' d='M3 0L6 4H0L3 0ZM3 10L0 6H6L3 10Z' fill='#95AAC9'/>
+</svg>

--- a/public/assets/svg/toggler-dark.svg
+++ b/public/assets/svg/toggler-dark.svg
@@ -1,0 +1,4 @@
+<svg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'>
+    <path stroke='#ffffff' stroke-opacity="0.5" stroke-width='2' stroke-linecap='round' stroke-miterlimit='10'
+          d='M4 7h22M4 15h22M4 23h22'/>
+</svg>

--- a/public/assets/svg/toggler-light.svg
+++ b/public/assets/svg/toggler-light.svg
@@ -1,0 +1,3 @@
+<svg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'>
+    <path stroke='#6E84A3' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/>
+</svg>


### PR DESCRIPTION
Allowing the `data:` schema for sources in the CSP is inherently unsafe. CSP doesn't have an easy way to allow some uses of `data:`.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src):
> This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.

Inlining svgs in css avoids the multiple HTTP connections needed to fetch the multiple files, but http/2 makes this much less beneficial because the same connection is reused for fetching multiple assets.

This PR moves all inlined CSS background-image and mask SVG into SVG files and references those files in the CSS. This avoids the need to modify the CSP.