### PR TITLE
Upgrade to Ubuntu 22.04 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
           paths:
             - "/tmp/workspace/.git"
 
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
 
       - run:
           name: Build portal image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
 jobs:
   build:
     docker:
-      - image: circleci/buildpack-deps:18.10-scm
+      - image: circleci/buildpack-deps:18.04-scm
 
     working_directory: *workspace_root
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
 jobs:
   build:
     docker:
-      - image: circleci/buildpack-deps:18.04-scm
+      - image: cimg/base:current-22.04
 
     working_directory: *workspace_root
 
@@ -55,7 +55,7 @@ jobs:
 
   deploy_to_production:
     docker:
-      - image: circleci/buildpack-deps:18.10-scm
+      - image: cimg/base:current-22.04
 
     working_directory: *workspace_root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.11 as base
+FROM phusion/baseimage:jammy-1.0.0 as base
 
 ENV LC_ALL C.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These instructions will get you set up and running with SSL through [LetsEncrypt
 
 **_If you are a current Sonar customer, and you need assistance with any part of this process, please don't hesitate to reach out to support@sonar.software for help. We are more than happy to help you get your portal setup!_**
 
-You'll need a machine running Ubuntu 16 or 18 x64. **Please note that the customer portal will not work Ubuntu 19, as Docker is currently unsupported.** The installation script currently assumes a Debian-based distro. We recommend a minimum of 2 vCPUs, at least 2GB of RAM, and at least 25 GB of storage.
+You'll need a machine running Ubuntu 18 or 22 x64. **Please note that the customer portal will not work Ubuntu 19, as Docker is currently unsupported.** The installation script currently assumes a Debian-based distro. We recommend a minimum of 2 vCPUs, at least 2GB of RAM, and at least 25 GB of storage.
 
 It will need a public facing IP address and a valid domain name pointing to it (e.g. portal.myisp.com).
 

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ if ! [ -x "$(command -v docker)" ]; then
        $(lsb_release -cs) \
        stable"
     apt-get update
-    apt-get install -y docker-ce docker-ce-cli
+    apt-get install -y docker-ce docker-ce-cli containerd.io
 fi
 
 if ! [ -x "$(command -v docker-compose)" ]; then

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ if ! [ -x "$(command -v docker)" ]; then
        $(lsb_release -cs) \
        stable"
     apt-get update
-    apt-get install -y docker-ce docker-ce-cli containerd.io=1.4.4-1
+    apt-get install -y docker-ce docker-ce-cli
 fi
 
 if ! [ -x "$(command -v docker-compose)" ]; then


### PR DESCRIPTION
* Tested script and image with no issues.
* Docker image will be upgraded to jammy:1.0.0 (Ubuntu 22.04 LTS)
* Tested host node as Ubuntu 22.04 LTS as well. Adjusted install script accordingly. 