### PR TITLE
AB#10097 customer portal  password complexity is not being enforced

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\AuthenticationRequest;
 use App\Http\Requests\LookupEmailRequest;
 use App\Http\Requests\PasswordUpdateRequest;
 use App\Http\Requests\SendPasswordResetRequest;
+use App\PasswordPolicy;
 use App\PasswordReset;
 use App\Services\LanguageService;
 use App\SystemSetting;
@@ -30,6 +31,13 @@ use SonarSoftware\CustomerPortalFramework\Exceptions\AuthenticationException;
 class AuthenticationController extends Controller
 {
     use Throttles;
+
+    private $passwordPolicy;
+
+    public function __construct()
+    {
+        $this->passwordPolicy = new PasswordPolicy();
+    }
 
     /**
      * Show the main login page
@@ -198,6 +206,10 @@ class AuthenticationController extends Controller
             return redirect()->back()->withErrors(utrans('errors.invalidEmailAddress', [], $request))->withInput();
         }
 
+        if (!$this->passwordPolicy->isPasswordValid($request->input('password'))) {
+            return redirect()->back()->withErrors(utrans("errors.passwordIsTooWeak"))->withInput();
+        }
+
         $accountAuthenticationController = new AccountAuthenticationController();
         try {
             $accountAuthenticationController->createUser(
@@ -334,6 +346,10 @@ class AuthenticationController extends Controller
             $this->incrementThrottleValue('password_update', hash('sha256', $token.$request->getClientIp()));
 
             return redirect()->back()->withErrors(utrans('errors.invalidEmailAddress', [], $request));
+        }
+
+        if (!$this->passwordPolicy->isPasswordValid($request->input('password'))) {
+            return redirect()->back()->withErrors(utrans("errors.passwordIsTooWeak"))->withInput();
         }
 
         $contactController = new ContactController();

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileUpdateRequest;
 use App\Http\Requests\UpdatePasswordRequest;
+use App\PasswordPolicy;
 use App\SystemSetting;
 use Carbon\Carbon;
 use Exception;
@@ -19,6 +20,13 @@ use SonarSoftware\CustomerPortalFramework\Models\PhoneNumber;
 
 class ProfileController extends Controller
 {
+    private $passwordPolicy;
+
+    public function __construct()
+    {
+        $this->passwordPolicy = new PasswordPolicy();
+    }
+
     public function show(): Factory|View
     {
         $user = get_user();
@@ -106,6 +114,10 @@ class ProfileController extends Controller
             );
         } catch (Exception $e) {
             return redirect()->back()->withErrors(utrans('errors.currentPasswordInvalid'));
+        }
+
+        if (!$this->passwordPolicy->isPasswordValid($request->input('new_password'))) {
+            return redirect()->back()->withErrors(utrans("errors.passwordIsTooWeak"))->withInput();
         }
 
         $contact = $this->getContact();

--- a/app/PasswordPolicy.php
+++ b/app/PasswordPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App;
+
+use ZxcvbnPhp\Zxcvbn;
+
+class PasswordPolicy
+{
+    private $zxcvbn;
+
+    public function __construct()
+    {
+        $this->zxcvbn = new Zxcvbn();
+    }
+
+    /**
+     * Validates the password based on Customer Portal settings.
+     * @param String $password Password to validate
+     * @return bool True if validation passed; otherwise, false.
+     */
+    public function isPasswordValid(String $password): bool
+    {
+        //The settings page was built with 1-5 instead of 0-4, fixing this here instead of making a migration.
+        $minimumPasswordStrength = SystemSetting::first()->password_strength_required - 1;
+        $zxcvbnResult = $this->zxcvbn->passwordStrength(substr($password, 0, 100));
+        return ($zxcvbnResult['score'] >= $minimumPasswordStrength);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "spatie/laravel-csp": "^2.8",
         "laravel/ui": "^4.2",
         "guzzlehttp/guzzle": "^7.2",
-        "spatie/laravel-ray": "^1.32"
+        "spatie/laravel-ray": "^1.32",
+        "bjeavons/zxcvbn-php": "^1.3"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f34d0c0de8399ff085c1aa18f014ba5",
+    "content-hash": "e5ee86de40fe9a1459fb3a8a336bd0ac",
     "packages": [
+        {
+            "name": "bjeavons/zxcvbn-php",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bjeavons/zxcvbn-php.git",
+                "reference": "994928ae5b17ecff8baa2406832d37bdf01116c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bjeavons/zxcvbn-php/zipball/994928ae5b17ecff8baa2406832d37bdf01116c0",
+                "reference": "994928ae5b17ecff8baa2406832d37bdf01116c0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.2 | ^8.0 | ^8.1",
+                "symfony/polyfill-mbstring": ">=1.3.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "*",
+                "phpunit/phpunit": "^8.5",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "ext-gmp": "Required for optimized binomial calculations (also requires PHP >= 7.3)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZxcvbnPhp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "See contributors",
+                    "homepage": "https://github.com/bjeavons/zxcvbn-php"
+                }
+            ],
+            "description": "Realistic password strength estimation PHP library based on Zxcvbn JS",
+            "homepage": "https://github.com/bjeavons/zxcvbn-php",
+            "keywords": [
+                "password",
+                "zxcvbn"
+            ],
+            "support": {
+                "issues": "https://github.com/bjeavons/zxcvbn-php/issues",
+                "source": "https://github.com/bjeavons/zxcvbn-php/tree/1.3.1"
+            },
+            "time": "2021-12-21T18:37:02+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.12.1",

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -8,6 +8,7 @@ return [
     'paymentFailed' => 'Payment failed. Please check your details and try again.',
     'failedToUpdateProfile' => 'Failed to update profile. Please try again later.',
     'currentPasswordInvalid' => 'Current password is incorrect.',
+    'passwordIsTooWeak' => 'Password is generally too weak or contains simple dictionary words.',
     'failedToDownloadInvoice' => 'Failed to download invoice. Please try again later.',
     'mustSetEmailAddress' => 'You must set your email address before you can create a ticket.',
     'sectionDisabled' => 'That section is disabled.',

--- a/resources/views/pages/config/show.blade.php
+++ b/resources/views/pages/config/show.blade.php
@@ -309,7 +309,8 @@
                      <label>
                      Required Password Strength
                      </label>
-                     {!! Form::select('password_strength_required', array('1' => 'Minimal', '2' => 'Low', '3' => 'Moderate', '4' => 'High', '5' => 'Maximum'), $systemSetting->password_strength_required,['id' => 'password_strength_required', 'class' => 'form-control', 'data-toggle' => 'select', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The password strength standard required for new users and password resets']); !!}
+                     {{-- These options are 1-5 instead of 0-4, avoiding a migration and handling the offset in PasswordPolicy->isPasswordValid() --}}
+                     {!! Form::select('password_strength_required', array('1' => 'Risky Password (0)', '2' => 'Very Guessable (1)', '3' => 'Somewhat Guessable (2)', '4' => 'Safely Unguessable (3)', '5' => 'Very Unguessable (4)'), $systemSetting->password_strength_required,['id' => 'password_strength_required', 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The password strength standard required for new users and password resets']); !!}
                   </div>
                </div>
             </div>
@@ -530,7 +531,7 @@
                      <label>
                      PayPal Currency
                      </label>
-                     {!! Form::select('paypal_currency_code', $paypalCurrency, $systemSetting->paypal_currency_code,['id' => 'paypal_currency_code', 'class' => 'form-control', 'data-toggle' => 'select', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The currency mode your PayPal account is configured for']); !!}
+                     {!! Form::select('paypal_currency_code', $paypalCurrency, $systemSetting->paypal_currency_code,['id' => 'paypal_currency_code', 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The currency mode your PayPal account is configured for']); !!}
                   </div>
                </div>
             </div>

--- a/resources/views/pages/config/show.blade.php
+++ b/resources/views/pages/config/show.blade.php
@@ -310,7 +310,29 @@
                      Required Password Strength
                      </label>
                      {{-- These options are 1-5 instead of 0-4, avoiding a migration and handling the offset in PasswordPolicy->isPasswordValid() --}}
-                     {!! Form::select('password_strength_required', array('1' => 'Risky Password (0)', '2' => 'Very Guessable (1)', '3' => 'Somewhat Guessable (2)', '4' => 'Safely Unguessable (3)', '5' => 'Very Unguessable (4)'), $systemSetting->password_strength_required,['id' => 'password_strength_required', 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The password strength standard required for new users and password resets']); !!}
+                     {!!
+                         Form::select(
+                            'password_strength_required',
+                            array(
+                                '1' => 'Risky Password (0)',
+                                '2' => 'Very Guessable (1)',
+                                '3' => 'Somewhat Guessable (2)',
+                                '4' => 'Safely Unguessable (3)',
+                                '5' => 'Very Unguessable (4)',
+                            ),
+                            $systemSetting->password_strength_required,
+                            [
+                                'id' => 'password_strength_required',
+                                'class' => 'form-control',
+                                'data-toggle' => 'tooltip',
+                                'data-trigger' => 'hover',
+                                'data-placement' => 'left',
+                                'data-offset' => '3',
+                                'data-html' => 'true',
+                                'data-original-title' => 'The password strength standard required for new users and password resets',
+                            ]
+                         );
+                     !!}
                   </div>
                </div>
             </div>
@@ -531,7 +553,23 @@
                      <label>
                      PayPal Currency
                      </label>
-                     {!! Form::select('paypal_currency_code', $paypalCurrency, $systemSetting->paypal_currency_code,['id' => 'paypal_currency_code', 'class' => 'form-control', 'data-toggle' => 'tooltip', 'data-trigger' => 'hover','data-placement' => 'left','data-offset' => '3','data-html' => 'true', 'data-original-title' => 'The currency mode your PayPal account is configured for']); !!}
+                     {!!
+                        Form::select(
+                            'paypal_currency_code',
+                            $paypalCurrency,
+                            $systemSetting->paypal_currency_code,
+                            [
+                                'id' => 'paypal_currency_code',
+                                'class' => 'form-control',
+                                'data-toggle' => 'tooltip',
+                                'data-trigger' => 'hover',
+                                'data-placement' => 'left',
+                                'data-offset' => '3',
+                                'data-html' => 'true',
+                                'data-original-title' => 'The currency mode your PayPal account is configured for'
+                            ]
+                        );
+                     !!}
                   </div>
                </div>
             </div>


### PR DESCRIPTION
Added server side password complexity checks to the customer portal. These checks will behave like the Minimum Password Strength setting sonar side. Updated settings page password complexity options to match the sonar options. Since the customer portal password complexity options that save to SQLite were accidentally created as 1-5 instead of 0-4 like zxcvbn outputs, the PasswordPolicy class is shifting them down to avoid a migration.