### PR TITLE
AB#5796 customer portal cant add or update phone number from the portal

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name', 'email', 'password',

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -52,4 +52,5 @@ return [
     '500error' => '500 Error',
     'apiPermissionsFailure' => 'Your API user is not setup with the correct permissions. Verify the permissions are setup per the <a href="https://github.com/SonarSoftwareInc/customer_portal/blob/master/README.md#a-note-on-initial-setup">readme</a> document.',
     'stripePaymentMethodNotFound' => 'No Stripe PaymentMethod found with that ID',
+    'phoneNumberNotValid' => "A phone number cannot be saved. Please remove it and try again.",
 ];

--- a/lang/fr/errors.php
+++ b/lang/fr/errors.php
@@ -47,4 +47,7 @@ return [
     'addAPaymentMethod' => 'Veuillez ajouter un mode de paiement à votre compte pour effectuer un paiement.',
     '500error' => 'Erreur 500',
     'apiPermissionsFailure' => 'Votre API ne contient pas les autorisations appropriées. Vérifiez que les autorisations soient configurées par le <a href="https://github.com/SonarSoftwareInc/customer_portal/blob/master/README.md#a-note-on-initial-setup">document Lisez-moi.</a>',
+    'stripePaymentMethodNotFound' => 'Aucune méthode de paiement Stripe trouvée avec cet identifiant',
+    'phoneNumberNotValid' => "Un numéro de téléphone ne peut pas être enregistré. Veuillez le supprimer et réessayer.",
 ];
+


### PR DESCRIPTION
Update: After rebasing, the most recent tiny commit was needed to clean up and needs a review before merging.

When saving phone numbers in the customer portal:
- Inputs will be kept after failures
- I've added the messaging below. If you have any suggestions for improving the text, please let me know.

Error Text: A phone number cannot be saved. Please remove it and try again.

This happens when there is phone number types mismatch between the customer portal and Sonar side. The customer portal will send Home, Mobile, Work, and Fax when they're set along with any other phone number types that are set Sonar side. However, the contact and phone numbers are loaded from the API and cached for 10 minutes, so this can cause some unexpected behavior when changing the phone number types on the Sonar side.

Related Customer Portal Framework PR: https://github.com/SonarSoftwareInc/customer_portal_framework/pull/11