### PR TITLE
AB#25101 customer portal paypal integration throws error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravelcollective/html": "^6.4",
         "proengsoft/laravel-jsvalidation": "^4.8",
         "paypal/rest-api-sdk-php": "^1.14",
-        "psr/log": "3.0 as 1.0",
+        "psr/log": "2.0 as 1.0",
         "mariuzzo/laravel-js-localization": "dev-master",
         "laravel/tinker": "^2.8",
         "gocardless/gocardless-pro": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2693d3c8de66b5ea51f1a97fdf4465a7",
+    "content-hash": "27595b105d01101f5d2287da1fbd18b6",
     "packages": [
         {
             "name": "brick/math",
@@ -3462,16 +3462,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
@@ -3480,7 +3480,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3506,9 +3506,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -9735,7 +9735,7 @@
     "aliases": [
         {
             "package": "psr/log",
-            "version": "3.0.0.0",
+            "version": "2.0.0.0",
             "alias": "1.0",
             "alias_normalized": "1.0.0.0"
         }


### PR DESCRIPTION
Laravel 10 requires monolog 3.
Monolog 3 requires psr/log 2|3.
paypal/rest-api-sdk-php 1.14 requires psr/log 1.

We originally aliased psr/log 3 to 1 to satisfy paypal/rest-api-sdk-php, but psr/log 3 adds an explicit `void` return type in `LoggerAbstract` that causes a fatal error when extended. In psr/log 2 there is no specified return type on the abstract, and so paypal/rest-api-sdk-php 1.14 remains compatible.