### PR TITLE
AB#33403 Use docker volume for FCC labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
       - ./public/assets/img/logo.png:/var/www/html/public/assets/img/logo.png
       - ./public/assets/img/cover.png:/var/www/html/public/assets/img/cover.png
+      - ./public/assets/fcclabels:/var/www/html/public/assets/fcclabels
       - storage:/var/www/html/storage
     env_file:
      - .env


### PR DESCRIPTION
Unfortunately when we added the FCC labels feature to client portal, we didnt make the upload directory a docker volume, so when the container resets, the FCC label zip needs to be uploaded again.

This makes the label directory persistent across restarts.