### PR TITLE
Fix FCC label disk volume

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,7 +21,12 @@ https://docs.sonar.expert/system/upgrading-your-ubuntu-os-customer-portal-upgrad
 	image: sonarsoftware/customerportal:next
 	```
 
-3. Start the customer portal
+3. Update the docker-compose.yml file so that the FCC labels directory is persisted.  In the `volumes` section under the `app` service, add the following line under the existing volumes listed.
+	```
+	- ./public/assets/fcclabels:/var/www/html/public/assets/fcclabels
+	```
+
+4. Start the customer portal
 	```
 	sudo docker-compose up -d
 	```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
       - ./public/assets/img/logo.png:/var/www/html/public/assets/img/logo.png
       - ./public/assets/img/cover.png:/var/www/html/public/assets/img/cover.png
+      - ./public/assets/fcclabels:/var/www/html/public/assets/fcclabels
       - storage:/var/www/html/storage
     env_file:
      - .env


### PR DESCRIPTION
Unfortunately when we added the FCC labels feature to client portal, we didnt make the upload directory a docker volume, so when the container resets, the FCC label zip needs to be uploaded again.

This makes the label directory persistent across restarts.