### PR TITLE
AB#34508 nginx: Increase client max body size

### DIFF
--- a/deploy/conf/nginx/sonar-customerportal.template
+++ b/deploy/conf/nginx/sonar-customerportal.template
@@ -41,5 +41,6 @@ server {
         fastcgi_pass unix:/run/php/php8.2-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        client_max_body_size 8M;
     }
 }

--- a/deploy/dev/sonar-customerportal-dev.template
+++ b/deploy/dev/sonar-customerportal-dev.template
@@ -18,5 +18,6 @@ server {
         fastcgi_pass unix:/run/php/php8.2-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        client_max_body_size 8M;
     }
 }


### PR DESCRIPTION
This PR adds the `client_max_body_size` setting into the nginx site configuration and sets it to 8M, matching the fpm/php.ini `post_max_size` which is 8M by default.