### PR TITLE
AB#36289 - Customer Portal > Error Adding Credit Cards to Customer Portal

### DIFF
--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -85,7 +85,7 @@ class BillingController extends Controller
         ];
 
         $systemSetting = SystemSetting::firstOrNew(['id' => 1]);
-        
+
         $services = $this->accountBillingController->getServices(get_user()->account_id);
         $dataServiceId = 0;
         if ($accountDetails->company_id) {
@@ -749,7 +749,7 @@ class BillingController extends Controller
             'name' => $request->input('name'),
             'number' => $card['number'],
             'expiration_month' => intval($month),
-            'expiration_year' => $year,
+            'expiration_year' => intval($year),
             'line1' => $request->input('line1'),
             'city' => $request->input('city'),
             'state' => $request->input('state'),

--- a/public/assets/js/pages/billing/payment/page.js
+++ b/public/assets/js/pages/billing/payment/page.js
@@ -97,11 +97,19 @@ function updateSubdivisions()
     var jqxhr = $.get("/portal/billing/subdivisions/" + country, function(data) {
         $("#state").empty();
         var show = false;
+        let initialValue = "";
         $.each(data.subdivisions, function (index, value) {
+            // When updating subdivisions there needs to be a default or we submit an invalid country / state combo
+            let selected = "";
+            if (show === false) {
+                selected = " selected=\"selected\"";
+                initialValue = index;
+            }
             show = true;
-           $("#state").append("<option value='" + index + "'>" + value + "</option>");
+           $("#state").append("<option value='" + index + "'" + selected + ">" + value + "</option>");
         });
         if (show === true) {
+            $("#state").val(initialValue);
             $("#stateWrapper").show();
         }
         else {

--- a/public/assets/js/pages/billing/payment/page_stripe.js
+++ b/public/assets/js/pages/billing/payment/page_stripe.js
@@ -194,11 +194,19 @@ function updateSubdivisions()
     var jqxhr = $.get("/portal/billing/subdivisions/" + country, function(data) {
         $("#state").empty();
         var show = false;
+        let initialValue = "";
         $.each(data.subdivisions, function (index, value) {
+            // When updating subdivisions there needs to be a default or we submit an invalid country / state combo
+            let selected = "";
+            if (show === false) {
+                selected = " selected=\"selected\"";
+                initialValue = index;
+            }
             show = true;
-           $("#state").append("<option value='" + index + "'>" + value + "</option>");
+            $("#state").append("<option value='" + index + "'" + selected + ">" + value + "</option>");
         });
         if (show === true) {
+            $("#state").val(initialValue);
             $("#stateWrapper").show();
         }
         else {


### PR DESCRIPTION
It was possible to get this error to show up by changing the country code only after having an error caused by some other validation.  This was not then updating the "state" code which caused us to have a mismatch between the country code / state code that was not valid being passed to Sonar.  

When the country code is changed and the state select repopulated the first entry is considered selected and the value for that set.  

While not related to the issues it was also discovered that they expiration year was not being converted to an int explicitly as the month was so this has been adjusted as well.