### PR TITLE
AB#37206 - Show multiple labels for FCC Broadband Facts.

### DIFF
--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -98,10 +98,7 @@ class BillingController extends Controller
                     if ($serviceDef->data_service) {
                         $svgPath = "/assets/fcclabels/label_" . $service->id . "_" . $accountDetails->company_id . ".svg";
                         if (file_exists(base_path("public{$svgPath}"))) {
-                            $svgs[] = [
-                                'display' => 'initial',
-                                'path' => $svgPath
-                            ];
+                            $svgs[] = $svgPath;
                         }
                     }
                 }

--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -87,36 +87,30 @@ class BillingController extends Controller
         $systemSetting = SystemSetting::firstOrNew(['id' => 1]);
 
         $services = $this->accountBillingController->getServices(get_user()->account_id);
-        $dataServiceId = 0;
+        $svgs = [];
+
         if ($accountDetails->company_id) {
             foreach ($services as $service) {
-                //save a call back to sonar if no label is here to find anyway
                 $trySvgPath = "public/assets/fcclabels/label_" . $service->id . "_" . $accountDetails->company_id . ".svg";
+
                 if (file_exists(base_path("{$trySvgPath}"))) {
                     $serviceDef = $this->systemController->getService($service->id);
                     if ($serviceDef->data_service) {
-                        $dataServiceId = $service->id;
+                        $svgPath = "/assets/fcclabels/label_" . $service->id . "_" . $accountDetails->company_id . ".svg";
+                        if (file_exists(base_path("public{$svgPath}"))) {
+                            $svgs[] = [
+                                'display' => 'initial',
+                                'path' => $svgPath
+                            ];
+                        }
                     }
                 }
             }
-
-            $svgPath = "/assets/fcclabels/label_" . $dataServiceId . "_" . $accountDetails->company_id . ".svg";
-
-            if (file_exists(base_path("public{$svgPath}"))) {
-                $svgDisplay = "initial";
-                $svg = file_get_contents(base_path("public{$svgPath}"));
-            } else {
-                $svgDisplay = "none";
-                $svg = "";
-            }
-        } else {//must be using v1
-            $svgDisplay = "none";
-            $svg = "";
         }
 
         return view(
             'pages.billing.index',
-            compact('values', 'invoices', 'transactions', 'paymentMethods', 'systemSetting', 'svg', 'svgDisplay', 'contact')
+            compact('values', 'invoices', 'transactions', 'paymentMethods', 'systemSetting', 'svgs', 'contact')
         );
     }
 

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -17,6 +17,7 @@ return [
     'downloadInvoice' => 'PDF',
     'transactionType' => 'Type',
     'dueDate' => 'Due Date',
+    'fccBroadbandFacts' => 'FCC Broadband Facts',
     'creditCardNumber' => 'Credit Card Number',
     'creditCardNumber--placeholder' => '1234 5678 9012 3456',
     'nameOnCard' => 'Name on Card',

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -456,15 +456,15 @@
             </div>
          </div>
       </div>
-      @if ($svgDisplay !== "none")
-      <div class="col-12 col-sm-10 col-md-10 col-lg-6 col-xl-4">
-         <div class="card">
-            <div style="display: {{ $svgDisplay }};">
-               {!! $svg !!}
+      @foreach($svgs as $svg)
+         <div class="col-12 col-sm-10 col-md-10 col-lg-6 col-xl-4">
+            <div class="card">
+               <div style="display: {{ $svg['display'] }};">
+                  <img src="{{ $svg['path'] }}" alt="FCC Broadband Facts">
+               </div>
             </div>
          </div>
-      </div>
-      @endif
+      @endforeach
    </div>
 </div>
 </div><!-- #main-content -->

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -459,9 +459,7 @@
       @foreach($svgs as $svg)
          <div class="col-12 col-sm-10 col-md-10 col-lg-6 col-xl-4">
             <div class="card">
-               <div style="display: {{ $svg['display'] }};">
-                  <img src="{{ $svg['path'] }}" alt="FCC Broadband Facts">
-               </div>
+               <img src="{{ $svg }}" alt="FCC Broadband Facts">
             </div>
          </div>
       @endforeach

--- a/resources/views/pages/billing/index.blade.php
+++ b/resources/views/pages/billing/index.blade.php
@@ -459,7 +459,7 @@
       @foreach($svgs as $svg)
          <div class="col-12 col-sm-10 col-md-10 col-lg-6 col-xl-4">
             <div class="card">
-               <img src="{{ $svg }}" alt="FCC Broadband Facts">
+               <img src="{{ $svg }}" alt="{{utrans("billing.fccBroadbandFacts")}}">
             </div>
          </div>
       @endforeach


### PR DESCRIPTION
Updated the Billing Controller to return multiple svgs (per data service on the account). In addition, I noticed the original `file_get_contents` was a touch slow to load the page. Instead I am returning the path and letting the template render the img from the assets path. I did notice a similar patter elsewhere - e.g: `<img class="logo-form" src="/assets/img/logo.png">` so I am assuming this is safe to do. 

<img width="1445" alt="Screenshot 2025-06-23 at 1 46 10 p m" src="https://github.com/user-attachments/assets/14ed3e19-f8ff-4eb9-bf02-cac2366d9b10" />
