### PR TITLE
Update Dockerfile to nginx stable instead of the depreciated main-line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL C.UTF-8
 ARG PHP_VERSION=8.2
 
 RUN add-apt-repository ppa:ondrej/php \
- && add-apt-repository ppa:ondrej/nginx-mainline \
+ && add-apt-repository ppa:ondrej/nginx \
  && install_clean \
       gettext \
       nginx \


### PR DESCRIPTION
Per https://github.com/oerdnj/deb.sury.org/issues/2292 main-line is no longer valid and should be replaced with the stable version.