### PR TITLE
[Bug Fix] Make email address comparison case-insensitive during passw…

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -342,7 +342,7 @@ class AuthenticationController extends Controller
                 ->withErrors(utrans('errors.invalidToken', [], $request));
         }
 
-        if ($passwordReset->email != $request->input('email')) {
+        if (strcasecmp($passwordReset->email, $request->input('email')) !== 0) {
             $this->incrementThrottleValue('password_update', hash('sha256', $token.$request->getClientIp()));
 
             return redirect()->back()->withErrors(utrans('errors.invalidEmailAddress', [], $request));


### PR DESCRIPTION
Changed email comparison between user input and Sonar contact email from case-sensitive to case-insensitive by using strcasecmp(). This ensures the input will validate properly during the password reset process even if the user-entered email and the Sonar contact email differ in capitalization.