### PR TITLE
AB#37078 - Phone number truncation

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -42,12 +42,16 @@ class ProfileController extends Controller
             PhoneNumber::FAX => null,
         ];
 
+        $country = SystemSetting::first()->country;
+
         foreach ($contact->getPhoneNumbers() as $phoneNumber) {
             if ($phoneNumber != null) {
-                $phoneNumbers[$phoneNumber->getType()] = $phoneNumber->getNumber();
+                $phoneNumbers[$phoneNumber->getType()] = $this->formatPhoneForDisplay(
+                    $phoneNumber->getNumber(),
+                    $country
+                );
             }
         }
-        $country = SystemSetting::first()->country;
 
         return view('pages.profile.show', compact('user', 'contact', 'phoneNumbers', 'country'));
     }
@@ -158,5 +162,19 @@ class ProfileController extends Controller
         }
 
         return utrans("errors.failedToUpdateProfile");
+    }
+
+    private function formatPhoneForDisplay(string $phoneNumber, string $country): string
+    {
+        if ($country !== 'US') return $phoneNumber;
+
+        $cleanNumber = preg_replace('/\D/', '', $phoneNumber);
+
+        //For US numbers, remove leading "1" if present
+        if (strlen($cleanNumber) === 11 && substr($cleanNumber, 0, 1) === '1') {
+            return substr($cleanNumber, 1);
+        }
+
+        return $cleanNumber;
     }
 }

--- a/public/assets/js/pages/billing/payment/page.js
+++ b/public/assets/js/pages/billing/payment/page.js
@@ -83,6 +83,18 @@ $(document).ready(function(){
 
     handlePaymentMethodChange();
 
+    $('#createPaymentMethodForm').on('submit', function() {
+        const $submitBtn = $('#createPaymentMethodSubmitButton');
+        $submitBtn.prop('disabled', true);
+
+        setTimeout(() => {
+            //Re-enable if there are inline validation errors
+            if ($('.has-error').length > 0) {
+                $submitBtn.prop('disabled', false);
+            }
+        }, 100);
+    });
+
     $("#paymentForm").submit(function () {
         var selectedPaymentMethod = $("#payment_method").val();
         switch (selectedPaymentMethod) {

--- a/resources/views/pages/billing/add_bank.blade.php
+++ b/resources/views/pages/billing/add_bank.blade.php
@@ -145,7 +145,7 @@
     <div class="row">
         <div class="col-12 col-md-12">
             <input type="hidden" name="payment_tracker_id" value="{{uniqid("", true)}}" />
-            <button type="submit" class="btn btn-primary">{{utrans("billing.addNewBankAccount")}}</button>
+            <button type="submit" id="createPaymentMethodSubmitButton" class="btn btn-primary">{{utrans("billing.addNewBankAccount")}}</button>
             {!! Form::close() !!}
         </div>
     </div>

--- a/resources/views/pages/billing/add_card.blade.php
+++ b/resources/views/pages/billing/add_card.blade.php
@@ -145,7 +145,7 @@
    <div class="row">
       <div class="col-12 col-md-12">
          <input type="hidden" name="payment_tracker_id" value="{{uniqid("", true)}}" />
-         <button type="submit" class="btn btn-primary">{{utrans("billing.addNewCard")}}</button>
+         <button type="submit" id="createPaymentMethodSubmitButton" class="btn btn-primary">{{utrans("billing.addNewCard")}}</button>
          {!! Form::close() !!}
       </div>
    </div>

--- a/resources/views/pages/billing/make_payment.blade.php
+++ b/resources/views/pages/billing/make_payment.blade.php
@@ -197,7 +197,7 @@
                   <label>
                      {{utrans("billing.country")}}
                   </label>
-                  {!! Form::select("country",countries(),config("customer_portal.country"),['id' => 'country', 'class' => 'form-control', 'required' => true]) !!}
+                  {!! Form::select("country", countries(), old('country', config("customer_portal.country")), ['id' => 'country', 'class' => 'form-control', 'required' => true]) !!}
                </div>
             </div>
             <div id="stateWrapper" class="col-12 col-md-6">
@@ -205,7 +205,7 @@
                   <label>
                      {{utrans("billing.state")}}
                   </label>
-                  {!! Form::select("state",subdivisions(config("customer_portal.country")),config("customer_portal.state"),['id' => 'state', 'class' => 'form-control', 'required' => true]) !!}
+                  {!! Form::select("state", subdivisions(old('country', config("customer_portal.country"))), old('state', config("customer_portal.state")), ['id' => 'state', 'class' => 'form-control', 'required' => true]) !!}
                </div>
             </div>
             <div class="col-12 col-md-6">


### PR DESCRIPTION
This PR takes care of three small Portal UI issues.

[Bug 37078](https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/37078): Customer Portal - Including a "1" before a 10 digit phone number will display in the portal with the last digit being truncated

The issue here is that if a user inputs a US phone number on an account with a leading 1, the existing template data mask would malform the number (non US numbers are rendered as-is)  My solution here is to simply truncate that leading 1. Another option would be to update the Portal Framework to include the `number_formatted` field, however I decided that is likely overkill for this edge case. 

[Bug 36078](https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/36078): Customer Portal > Make a Payment - Country and State/Province revert to U.S.

This was a simple addition of blade's `old()` template function to retrieve the session data on validation redirects.

[Bug 36278](https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/36278): Customer Portal > Clicking submit multiple times adds duplicate bank account payment methods

Required a bit of JS to disable the button on submit. 