### PR TITLE
AB#36078 - Submission Issues

### DIFF
--- a/public/assets/js/pages/billing/payment/page.js
+++ b/public/assets/js/pages/billing/payment/page.js
@@ -83,6 +83,18 @@ $(document).ready(function(){
 
     handlePaymentMethodChange();
 
+    $('#createPaymentMethodForm').on('submit', function() {
+        const $submitBtn = $('#createPaymentMethodSubmitButton');
+        $submitBtn.prop('disabled', true);
+
+        setTimeout(() => {
+            //Re-enable if there are inline validation errors
+            if ($('.has-error').length > 0) {
+                $submitBtn.prop('disabled', false);
+            }
+        }, 100);
+    });
+
     $("#paymentForm").submit(function () {
         var selectedPaymentMethod = $("#payment_method").val();
         switch (selectedPaymentMethod) {

--- a/resources/views/pages/billing/add_bank.blade.php
+++ b/resources/views/pages/billing/add_bank.blade.php
@@ -145,7 +145,7 @@
     <div class="row">
         <div class="col-12 col-md-12">
             <input type="hidden" name="payment_tracker_id" value="{{uniqid("", true)}}" />
-            <button type="submit" class="btn btn-primary">{{utrans("billing.addNewBankAccount")}}</button>
+            <button type="submit" id="createPaymentMethodSubmitButton" class="btn btn-primary">{{utrans("billing.addNewBankAccount")}}</button>
             {!! Form::close() !!}
         </div>
     </div>

--- a/resources/views/pages/billing/add_card.blade.php
+++ b/resources/views/pages/billing/add_card.blade.php
@@ -145,7 +145,7 @@
    <div class="row">
       <div class="col-12 col-md-12">
          <input type="hidden" name="payment_tracker_id" value="{{uniqid("", true)}}" />
-         <button type="submit" class="btn btn-primary">{{utrans("billing.addNewCard")}}</button>
+         <button type="submit" id="createPaymentMethodSubmitButton" class="btn btn-primary">{{utrans("billing.addNewCard")}}</button>
          {!! Form::close() !!}
       </div>
    </div>

--- a/resources/views/pages/billing/make_payment.blade.php
+++ b/resources/views/pages/billing/make_payment.blade.php
@@ -197,7 +197,7 @@
                   <label>
                      {{utrans("billing.country")}}
                   </label>
-                  {!! Form::select("country",countries(),config("customer_portal.country"),['id' => 'country', 'class' => 'form-control', 'required' => true]) !!}
+                  {!! Form::select("country", countries(), old('country', config("customer_portal.country")), ['id' => 'country', 'class' => 'form-control', 'required' => true]) !!}
                </div>
             </div>
             <div id="stateWrapper" class="col-12 col-md-6">
@@ -205,7 +205,7 @@
                   <label>
                      {{utrans("billing.state")}}
                   </label>
-                  {!! Form::select("state",subdivisions(config("customer_portal.country")),config("customer_portal.state"),['id' => 'state', 'class' => 'form-control', 'required' => true]) !!}
+                  {!! Form::select("state", subdivisions(old('country', config("customer_portal.country"))), old('state', config("customer_portal.state")), ['id' => 'state', 'class' => 'form-control', 'required' => true]) !!}
                </div>
             </div>
             <div class="col-12 col-md-6">


### PR DESCRIPTION
This PR takes care of two small Portal UI issues.

[Bug 36078](https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/36078): Customer Portal > Make a Payment - Country and State/Province revert to U.S.

This was a simple addition of blade's old() template function to retrieve the session data on validation redirects.

[Bug 36278](https://dev.azure.com/sonarsoftware/Sonar/_workitems/edit/36278): Customer Portal > Clicking submit multiple times adds duplicate bank account payment methods

Required a bit of JS to disable the button on submit.