### PR TITLE
AB#40210 - Migrate to WUD for self-update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a prebuilt and self-hosted customer portal for [Sonar](https://sonar.sof
 
 ## Quick start
 
-These instructions will get you set up and running with SSL through [LetsEncrypt](https://letsencrypt.org) as well as automatic updates provided by [Watchtower](https://github.com/v2tec/watchtower).
+These instructions will get you set up and running with SSL through [LetsEncrypt](https://letsencrypt.org) as well as automatic updates provided by [WUD (What's Up Docker)](https://github.com/getwud/wud).
 
 **_If you are a current Sonar customer, and you need assistance with any part of this process, please don't hesitate to reach out to support@sonar.software for help. We are more than happy to help you get your portal setup!_**
 
@@ -80,7 +80,7 @@ From the `customer_portal` directory, you can execute `sudo docker-compose exec 
 
 ## Upgrading
 
-Upgrades for the customer portal are done automatically and require no interaction on your part! The customer portal will automatically check for updates every 5 minutes and update itself. For further customization such as setting an update window or configuring email and/or Slack notifications, please see https://github.com/v2tec/watchtower
+Upgrades for the customer portal are done automatically and require no interaction on your part! The customer portal will automatically check for updates and update itself. For further customization such as configuring notifications, please see https://github.com/getwud/wud
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,10 @@ services:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
 
-  wud:
+
+  selfupdater:
     image: getwud/wud
-    container_name: wud
+    container_name: selfupdater
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -51,6 +52,7 @@ services:
       - WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false
       - WUD_TRIGGER_DOCKERCOMPOSE_LOCAL_FILE=/wud/docker-compose.yml
       - WUD_TRIGGER_DOCKERCOMPOSE_LOCAL_PRUNE=true
+      - WUD_WATCHER_LOCAL_CRON=5 * * * *
 
 volumes:
   storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       REDIS_HOST: redis
     labels:
       - wud.watch=true
+      - wud.watch.digest=true
     depends_on:
       - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
      - .env
     environment:
       REDIS_HOST: redis
+    labels:
+      - wud.watch=true
     depends_on:
       - redis
 
@@ -37,12 +39,17 @@ services:
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
 
-  watchtower:
-    image: v2tec/watchtower
+  wud:
+    image: getwud/wud
+    container_name: wud
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: sonar-customerportal
+      - ./docker-compose.yml:/wud/docker-compose.yml
+    environment:
+      - WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false
+      - WUD_TRIGGER_DOCKERCOMPOSE_LOCAL_FILE=/wud/docker-compose.yml
+      - WUD_TRIGGER_DOCKERCOMPOSE_LOCAL_PRUNE=true
 
 volumes:
   storage:


### PR DESCRIPTION
Watchtower is no longer functional with more recent Docker API versions and has no viable upgrade path. This replaces watchtower with What's Up Docker (WUD) to restore self-update functionality.

The operating model is compatible but configuration is slightly different. Any users who had update notifications configured with watchtower will require additional assistance to migrate.