### PR TITLE
AB#42124 Customer Portal > Password Reset > Complex Passwords Incorrectly Rejected as “Too Simple”

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -361,6 +361,7 @@ class AuthenticationController extends Controller
         try {
             $contactController->updateContactPassword($contact, $request->input('password'));
         } catch (Exception $e) {
+            report($e);
             return redirect()->back()->withErrors(utrans('errors.failedToResetPassword', [], $request));
         }
 

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -28,7 +28,7 @@ return [
     'tooManyFailedCreationAttempts' => 'You\'ve failed to create an account too many times in a short period of time. Please wait a few minutes and try again.',
     'tooManyFailedPasswordResets' => 'You\'ve failed to reset your password too many times in a short period of time. Please wait a few minutes and try again.',
     'couldNotFindAccount' => 'Sorry, but your account could not be found. Please try again later or try registering a new account.',
-    'failedToResetPassword' => 'Your password is too simple. Please try a longer and more complex password.',
+    'failedToResetPassword' => 'Account reset failed. Please contact support.',
     'tokenMismatch' => 'Looks like you may have been idle too long. Please try again.',
     'failedToPostReply' => 'Failed to post reply. Please try again later.',
     'paymentMethodNotFound' => 'That payment method could not be found. Perhaps it was already deleted.',


### PR DESCRIPTION
 ## [AB#42124](https://dev.azure.com/sonarsoftware/14e78b7e-d627-451d-9250-8c2db62a445e/_workitems/edit/42124): Fix Password Reset Authorization Error

  ### Problem
  Customer portal password reset rejects valid complex passwords with misleading error "Your password is too
  simple." Root cause: authorization failure, not validation.

  ### Root Cause
  UPDATE_CONTACT permission was missing from Customer Portal role in Sonar. API users could create/delete
  contacts but not update them, causing UpdateContactMutation authorization failure.

  ### Changes
  1. **Error Message Fix** (CD-MSG-02)
     - Updated `lang/en/errors.php`: Changed misleading message to generic "Account reset failed. Please contact
   support."
     - Integrated Bugsnag reporting: `report($e)`

  ### Verification
  Crashtest testing confirmed: With UPDATE_CONTACT enabled on Customer Portal role → password reset succeeds.

  ### Impact
  - Password reset now works with valid complex passwords
  - Accurate error messaging
  - No breaking changes, fully backwards compatible

https://www.notion.so/sonarsoftware/AB-42124-Password-Reset-Authorization-Fix-33ccb50d431d8175820afb9cf68624cd