### PR TITLE
AB#42124 customer portal  password reset  complex pass

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -361,6 +361,7 @@ class AuthenticationController extends Controller
         try {
             $contactController->updateContactPassword($contact, $request->input('password'));
         } catch (Exception $e) {
+            report($e);
             return redirect()->back()->withErrors(utrans('errors.failedToResetPassword', [], $request));
         }
 

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -28,7 +28,7 @@ return [
     'tooManyFailedCreationAttempts' => 'You\'ve failed to create an account too many times in a short period of time. Please wait a few minutes and try again.',
     'tooManyFailedPasswordResets' => 'You\'ve failed to reset your password too many times in a short period of time. Please wait a few minutes and try again.',
     'couldNotFindAccount' => 'Sorry, but your account could not be found. Please try again later or try registering a new account.',
-    'failedToResetPassword' => 'Your password is too simple. Please try a longer and more complex password.',
+    'failedToResetPassword' => 'Account reset failed. Please contact support.',
     'tokenMismatch' => 'Looks like you may have been idle too long. Please try again.',
     'failedToPostReply' => 'Failed to post reply. Please try again later.',
     'paymentMethodNotFound' => 'That payment method could not be found. Perhaps it was already deleted.',


### PR DESCRIPTION
Fixes Customer Portal password reset failures that were incorrectly reported as “password too simple.” Root cause was authorization, not validation: the Customer Portal role (id=13) lacked the UPDATE_CONTACT
 permission, so the reset flow could not update the contact record and surfaced a misleading generic error.
 
This PR updates the reset failure messaging to a neutral, accurate “Account reset failed. Please contact support.” and ensures exceptions are reported (Bugsnag) for debugging. The production remediation is a data change: add UPDATE_CONTACT
 to the Customer Portal role’s applied permissions (mutation provided) so API users can successfully update contact passwords. Verified in staging by toggling the permission: disabled → reset fails; enabled → reset succeeds.

Details:
https://www.notion.so/sonarsoftware/AB-42124-Password-Reset-Authorization-Fix-33ccb50d431d8175820afb9cf68624cd?t=34bcb50d431d808d957a00a932ab4feb