### PR TITLE
AB#41462 sonarpay  customer portal  adding new credit card while making payment creates multiple auth transactions

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -361,6 +361,7 @@ class AuthenticationController extends Controller
         try {
             $contactController->updateContactPassword($contact, $request->input('password'));
         } catch (Exception $e) {
+            report($e);
             return redirect()->back()->withErrors(utrans('errors.failedToResetPassword', [], $request));
         }
 

--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -361,7 +361,7 @@ class AuthenticationController extends Controller
         try {
             $contactController->updateContactPassword($contact, $request->input('password'));
         } catch (Exception $e) {
-            report($e);
+            Log::error($e);
             return redirect()->back()->withErrors(utrans('errors.failedToResetPassword', [], $request));
         }
 

--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -549,9 +549,7 @@ class BillingController extends Controller
         }
 
         if ($result->success !== true) {
-            // Check if card was saved despite payment failure
-            if (strpos($result->message, 'Card saved but') !== false) {
-                // Card saved but payment failed - return result so it can be communicated
+            if ($result->message !== '') {
                 return $result;
             }
             // Otherwise card save failed - throw exception (status quo)

--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -283,7 +283,7 @@ class BillingController extends Controller
     {
         $paymentMethods = $this->getPaymentMethods();
         foreach ($paymentMethods as $paymentMethod) {
-            if ((int) $paymentMethod->id === (int) $id) {
+            if ((int)$paymentMethod->id === (int)$id) {
                 try {
                     $this->accountBillingController->deletePaymentMethodByID(get_user()->account_id, $id);
                     $this->clearBillingCache();
@@ -307,13 +307,13 @@ class BillingController extends Controller
     {
         $paymentMethods = $this->getPaymentMethods();
         foreach ($paymentMethods as $paymentMethod) {
-            if ((int) $paymentMethod->id === (int) $id) {
+            if ((int)$paymentMethod->id === (int)$id) {
                 try {
-                    $existingAutoSetting = (bool) $paymentMethod->auto;
+                    $existingAutoSetting = (bool)$paymentMethod->auto;
                     $this->accountBillingController->setAutoOnPaymentMethod(
                         get_user()->account_id,
                         $paymentMethod->id,
-                        ! $existingAutoSetting
+                        !$existingAutoSetting
                     );
                     $this->clearBillingCache();
                     if ($existingAutoSetting === true) {
@@ -342,12 +342,12 @@ class BillingController extends Controller
         $billingDetails = $this->getAccountBillingDetails();
         $systemSettings = SystemSetting::first();
         $date = Carbon::now(config('app.timezone'))->format('Y-m-d');
-        
+
         switch ($type) {
             case 'credit_card':
                 if (config('customer_portal.stripe_enabled') == 1) {
                     $stripe = new PortalStripe();
-                   
+
                     return view('pages.billing.add_card_stripe', [
                         'secret' => $stripe->setupIntent(),
                         'key' => $systemSettings->stripe_public_api_key,
@@ -409,7 +409,7 @@ class BillingController extends Controller
             $this->accountBillingController->createTokenizedCreditCard(
                 get_user()->account_id,
                 $card,
-                (bool) $request->input('auto')
+                (bool)$request->input('auto')
             );
         } catch (Exception $e) {
             return redirect()->back()->withErrors(utrans('errors.failedToCreateCard'))->withInput();
@@ -439,7 +439,7 @@ class BillingController extends Controller
             $this->accountBillingController->createCreditCard(
                 get_user()->account_id,
                 $card,
-                (bool) $request->input('auto')
+                (bool)$request->input('auto')
             );
         } catch (Exception $e) {
             return redirect()->back()->withErrors(utrans('errors.failedToCreateCard'))->withInput();
@@ -479,7 +479,7 @@ class BillingController extends Controller
             $this->accountBillingController->createBankAccount(
                 get_user()->account_id,
                 $bankAccount,
-                (bool) $request->input('auto'),
+                (bool)$request->input('auto'),
                 $address
             );
         } catch (Exception $e) {
@@ -541,7 +541,7 @@ class BillingController extends Controller
                 get_user()->account_id,
                 $creditCard,
                 $request->input('amount'),
-                (bool) $request->input('makeAuto'),
+                (bool)$request->input('makeAuto'),
                 $request->input('payment_tracker_id')
             );
         } catch (Exception $e) {
@@ -574,7 +574,7 @@ class BillingController extends Controller
                 get_user()->account_id,
                 $creditCard,
                 $request->input('amount'),
-                (bool) $request->input('makeAuto'),
+                (bool)$request->input('makeAuto'),
                 $request->input('payment_tracker_id')
             );
         } catch (Exception $e) {
@@ -596,7 +596,7 @@ class BillingController extends Controller
      */
     private function getAccountBillingDetails(): mixed
     {
-        if (! Cache::tags('billing.details')->has(get_user()->account_id)) {
+        if (!Cache::tags('billing.details')->has(get_user()->account_id)) {
             $billingDetails = $this->accountBillingController->getAccountBillingDetails(get_user()->account_id);
             Cache::tags('billing.details')->put(
                 get_user()->account_id,
@@ -608,12 +608,12 @@ class BillingController extends Controller
         return Cache::tags('billing.details')->get(get_user()->account_id);
     }
 
-    /** 
+    /**
      * Get outstanding account invoices
      */
     private function getOutstandingAccountInvoices(): mixed
     {
-        if(!Cache::tags('billing.outstanding_invoices')->has(get_user()->account_id)) {
+        if (!Cache::tags('billing.outstanding_invoices')->has(get_user()->account_id)) {
             $invoices = $this->accountBillingController->getInvoicesOutstanding(get_user()->account_id);
             Cache::tags('billing.outstanding_invoices')->put(
                 get_user()->account_id,
@@ -630,7 +630,7 @@ class BillingController extends Controller
      */
     private function getInvoices(): mixed
     {
-        if (! Cache::tags('billing.invoices')->has(get_user()->account_id)) {
+        if (!Cache::tags('billing.invoices')->has(get_user()->account_id)) {
             $invoicesToReturn = [];
             $invoices = $this->accountBillingController->getInvoices(get_user()->account_id);
             foreach ($invoices as $invoice) {
@@ -658,7 +658,7 @@ class BillingController extends Controller
      */
     private function getTransactions(): mixed
     {
-        if (! Cache::tags('billing.transactions')->has(get_user()->account_id)) {
+        if (!Cache::tags('billing.transactions')->has(get_user()->account_id)) {
             $transactions = [];
             $debits = $this->accountBillingController->getDebits(get_user()->account_id);
             foreach ($debits as $debit) {
@@ -819,7 +819,7 @@ class BillingController extends Controller
             $request->input('expirationDate')
         );
 
-        if (! CreditCardValidator::validDate($year, $month)) {
+        if (!CreditCardValidator::validDate($year, $month)) {
             throw new InvalidArgumentException(utrans('errors.invalidExpirationDate'));
         }
 
@@ -846,7 +846,7 @@ class BillingController extends Controller
             $request->input('expirationDate')
         );
 
-        if (! CreditCardValidator::validDate($year, $month)) {
+        if (!CreditCardValidator::validDate($year, $month)) {
             throw new InvalidArgumentException(utrans('errors.invalidExpirationDate'));
         }
 
@@ -891,16 +891,16 @@ class BillingController extends Controller
             if (!empty($standardRouting) && strlen($standardRouting) === 9) {
                 return $standardRouting;
             }
-            
+
             // Canadian format: 0 + institution number (3 digits) + transit number (5 digits)
             $institutionNumber = str_pad($request->input('institution_number'), 3, '0', STR_PAD_LEFT);
             $transitNumber = str_pad($request->input('transit_number'), 5, '0', STR_PAD_LEFT);
-            
+
 
             // Routing number format: 0 + Institution Number (YYY) + Transit Number (XXXXX)
             return '0' . $institutionNumber . $transitNumber;
         }
-        
+
         return trim($request->input('routing_number'));
     }
 
@@ -909,7 +909,7 @@ class BillingController extends Controller
      */
     private function getPolicyDetails(): mixed
     {
-        if (! Cache::tags('usage_based_billing_policy_details')->has(get_user()->account_id)) {
+        if (!Cache::tags('usage_based_billing_policy_details')->has(get_user()->account_id)) {
             $policyDetails = $this->frameworkDataUsageController->getUsageBasedBillingPolicyDetails(
                 get_user()->account_id
             );
@@ -928,7 +928,7 @@ class BillingController extends Controller
      */
     private function getHistoricalUsage(): mixed
     {
-        if (! Cache::tags('historical_data_usage')->has(get_user()->account_id)) {
+        if (!Cache::tags('historical_data_usage')->has(get_user()->account_id)) {
             $dataUsage = $this->formatHistoricalUsageData(
                 array_slice(
                     $this->frameworkDataUsageController->getAggregatedDataUsage(get_user()->account_id),
@@ -977,7 +977,7 @@ class BillingController extends Controller
 
         $requestUrl = $this->cleanUrl(request()->url());
 
-        if (isset($options['path']) && $_SERVER['HTTP_HOST'].$options['path'] == $requestUrl) {
+        if (isset($options['path']) && $_SERVER['HTTP_HOST'] . $options['path'] == $requestUrl) {
             $page = request()->input('page', 1); // Get the current page or default to 1
         } else {
             $page = 1; // Get the current page or default to 1

--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -272,7 +272,7 @@ class BillingController extends Controller
                 ->action([BillingController::class, 'index'])
                 ->with('success', utrans('billing.paymentWasSuccessful'));
         } else {
-            return redirect()->back()->withErrors(utrans('errors.paymentFailed'));
+            return redirect()->back()->withErrors($result->message)->withInput();
         }
     }
 
@@ -549,6 +549,12 @@ class BillingController extends Controller
         }
 
         if ($result->success !== true) {
+            // Check if card was saved despite payment failure
+            if (strpos($result->message, 'Card saved but') !== false) {
+                // Card saved but payment failed - return result so it can be communicated
+                return $result;
+            }
+            // Otherwise card save failed - throw exception (status quo)
             throw new InvalidArgumentException(utrans('errors.paymentFailed'));
         }
 

--- a/app/Http/Controllers/BillingController.php
+++ b/app/Http/Controllers/BillingController.php
@@ -272,7 +272,7 @@ class BillingController extends Controller
                 ->action([BillingController::class, 'index'])
                 ->with('success', utrans('billing.paymentWasSuccessful'));
         } else {
-            return redirect()->back()->withErrors($result->message)->withInput();
+            return redirect()->back()->withErrors(utrans('errors.paymentFailed', ['error' => $result->message], $request))->withInput();
         }
     }
 

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Invalid username or password.',
     'invalidCreditCardNumber' => 'That credit card number is invalid.',
     'invalidExpirationDate' => 'That credit card has expired.',
-    'paymentFailed' => 'Payment failed. Please check your details, following processor message and try again. {error}',
+    'paymentFailed' => 'Payment failed: {error}. Please check your details and try again.',
     'failedToUpdateProfile' => 'Failed to update profile. Please try again later.',
     'currentPasswordInvalid' => 'Current password is incorrect.',
     'passwordIsTooWeak' => 'Password is generally too weak or contains simple dictionary words.',

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -28,7 +28,7 @@ return [
     'tooManyFailedCreationAttempts' => 'You\'ve failed to create an account too many times in a short period of time. Please wait a few minutes and try again.',
     'tooManyFailedPasswordResets' => 'You\'ve failed to reset your password too many times in a short period of time. Please wait a few minutes and try again.',
     'couldNotFindAccount' => 'Sorry, but your account could not be found. Please try again later or try registering a new account.',
-    'failedToResetPassword' => 'Your password is too simple. Please try a longer and more complex password.',
+    'failedToResetPassword' => 'Account reset failed. Please contact support.',
     'tokenMismatch' => 'Looks like you may have been idle too long. Please try again.',
     'failedToPostReply' => 'Failed to post reply. Please try again later.',
     'paymentMethodNotFound' => 'That payment method could not be found. Perhaps it was already deleted.',

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Invalid username or password.',
     'invalidCreditCardNumber' => 'That credit card number is invalid.',
     'invalidExpirationDate' => 'That credit card has expired.',
-    'paymentFailed' => 'Payment failed. Please check your details and try again.',
+    'paymentFailed' => 'Payment failed. Please check your details, following processor message and try again. {error}',
     'failedToUpdateProfile' => 'Failed to update profile. Please try again later.',
     'currentPasswordInvalid' => 'Current password is incorrect.',
     'passwordIsTooWeak' => 'Password is generally too weak or contains simple dictionary words.',

--- a/lang/es/errors.php
+++ b/lang/es/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Usuario o contraseña inválidos.',
     'invalidCreditCardNumber' => 'Ese número de tarjeta de crédito es inválido.',
     'invalidExpirationDate' => 'Esa tarjeta de crédito ha expirado.',
-    'paymentFailed' => 'El pago falló. Por favor verifica tus datos, el siguiente mensaje del procesador e inténtalo de nuevo. {error}',
+    'paymentFailed' => 'El pago falló: {error}. Por favor verifica tus datos e inténtalo de nuevo.',
     'failedToUpdateProfile' => 'Error al actualizar el perfil. Por favor, inténtalo más tarde.',
     'currentPasswordInvalid' => 'La contraseña actual es incorrecta.',
     'passwordIsTooWeak' => 'La contraseña es demasiado débil o contiene palabras comunes del diccionario.',

--- a/lang/es/errors.php
+++ b/lang/es/errors.php
@@ -28,7 +28,7 @@ return [
     'tooManyFailedCreationAttempts' => 'Has fallado demasiadas veces al crear una cuenta en un corto período de tiempo. Por favor espera unos minutos e inténtalo de nuevo.',
     'tooManyFailedPasswordResets' => 'Has fallado demasiadas veces al restablecer tu contraseña en un corto período de tiempo. Por favor espera unos minutos e inténtalo de nuevo.',
     'couldNotFindAccount' => 'Lo sentimos, no se pudo encontrar tu cuenta. Por favor, inténtalo de nuevo más tarde o intenta registrar una nueva cuenta.',
-    'failedToResetPassword' => 'Tu contraseña es demasiado simple. Por favor, intenta una contraseña más larga y compleja.',
+    'failedToResetPassword' => 'Ocurrió un error al restablecer la cuenta. Por favor, contacta a soporte técnico.',
     'tokenMismatch' => 'Parece que has estado inactivo demasiado tiempo. Por favor, inténtalo de nuevo.',
     'failedToPostReply' => 'Error al publicar la respuesta. Por favor, inténtalo más tarde.',
     'paymentMethodNotFound' => 'Ese método de pago no se pudo encontrar. Quizás ya fue eliminado.',

--- a/lang/es/errors.php
+++ b/lang/es/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Usuario o contraseña inválidos.',
     'invalidCreditCardNumber' => 'Ese número de tarjeta de crédito es inválido.',
     'invalidExpirationDate' => 'Esa tarjeta de crédito ha expirado.',
-    'paymentFailed' => 'El pago falló. Por favor verifica tus datos e inténtalo de nuevo.',
+    'paymentFailed' => 'El pago falló. Por favor verifica tus datos, el siguiente mensaje del procesador e inténtalo de nuevo. {error}',
     'failedToUpdateProfile' => 'Error al actualizar el perfil. Por favor, inténtalo más tarde.',
     'currentPasswordInvalid' => 'La contraseña actual es incorrecta.',
     'passwordIsTooWeak' => 'La contraseña es demasiado débil o contiene palabras comunes del diccionario.',

--- a/lang/fr/errors.php
+++ b/lang/fr/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Nom d’utilisateur ou mot de passe invalide.',
     'invalidCreditCardNumber' => 'Ce numéro de carte bancaire n’est pas valide.',
     'invalidExpirationDate' => 'Cette carte de crédit est expirée.',
-    'paymentFailed' => 'Le paiement a échoué. Veuillez vérifier la carte et réessayer. ',
+    'paymentFailed' => 'Le paiement a échoué. Veuillez vérifier vos informations, le message suivant du processeur et réessayer. {error}',
     'failedToUpdateProfile' => 'Impossible de mettre à jour ce profil. Veuillez réessayer plus tard.',
     'currentPasswordInvalid' => 'Mot de passe actuel est incorrect.',
     'failedToDownloadInvoice' => 'Impossible de télécharger la facture. Veuillez réessayer plus tard.',

--- a/lang/fr/errors.php
+++ b/lang/fr/errors.php
@@ -27,7 +27,7 @@ return [
     'tooManyFailedPasswordResets' => 'Vous avez tenté de réinitialiser votre mot de passe trop souvent en peu de temps. Veuillez attendre quelques minutes et réessayer.',
     'couldNotFindAccount' => 'Désolé mais votre compte est introuvable. Veuillez réessayer plus tard ou essayez d’enregistrer un nouveau compte.',
     'failedToLookupSubdivision' => 'Nous n’étions pas en mesure de chercher les États pour ce pays. S’il vous plaît rafraîchir et essayez à nouveau.',
-    'failedToResetPassword' => 'La réinitialisation du mot de passe a échoué. Veuillez réessayer plus tard.',
+    'failedToResetPassword' => 'Échec de la réinitialisation du compte. Veuillez contacter le support.',
     'tokenMismatch' => 'Période d’inactivité trop longue. Veuillez réessayer.',
     'failedToPostReply' => 'Impossible d’afficher la réponse. Veuillez réessayer plus tard.',
     'paymentMethodNotFound' => 'Cette méthode de paiement est introuvable. Elle a peut-être déjà été supprimée.',

--- a/lang/fr/errors.php
+++ b/lang/fr/errors.php
@@ -5,7 +5,7 @@ return [
     'loginFailed' => 'Nom d’utilisateur ou mot de passe invalide.',
     'invalidCreditCardNumber' => 'Ce numéro de carte bancaire n’est pas valide.',
     'invalidExpirationDate' => 'Cette carte de crédit est expirée.',
-    'paymentFailed' => 'Le paiement a échoué. Veuillez vérifier vos informations, le message suivant du processeur et réessayer. {error}',
+    'paymentFailed' => 'Le paiement a échoué: {error}. Veuillez vérifier vos informations et réessayer.',
     'failedToUpdateProfile' => 'Impossible de mettre à jour ce profil. Veuillez réessayer plus tard.',
     'currentPasswordInvalid' => 'Mot de passe actuel est incorrect.',
     'failedToDownloadInvoice' => 'Impossible de télécharger la facture. Veuillez réessayer plus tard.',


### PR DESCRIPTION
Prevent Payrix from creating multiple customer profiles during autopay card creation

Problem: When users created new credit cards with autopay enabled, Payrix created duplicate profiles because first_successful_transaction_id (from the $0 authorization) was lost during the card creation-then-payment flow.

Solution: Simplified the payment flow to:

    Create card FIRST with auto=true (preserves first_successful_transaction_id)
    Extract card ID from response
    Use the same payment endpoint as existing cards (accepts payment_method_id)

Further details:
https://www.notion.so/34acb50d431d8117962ada74e7729283